### PR TITLE
Include subworkflows folder

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include workflows/*.cwl
+include subworkflows/*.cwl
 include expressiontools/*.cwl
 include metadata/*.cwl
 include tools/*.cwl

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
     include_package_data=True,
     package_data={
         'biowardrobe_cwl_workflows': ['workflows/*.cwl',
+                                      'subworkflows/*.cwl',
                                       'expressiontools/*.cwl',
                                       'metadata/*.cwl',
                                       'tools/*.cwl',


### PR DESCRIPTION
Fixed missing `subworkflows` folder when installing with `pip` 