### PR TITLE
Bug fix, alternative option to set chromosome_list input

### DIFF
--- a/tools/ucsc-twobit-to-fa.cwl
+++ b/tools/ucsc-twobit-to-fa.cwl
@@ -27,8 +27,9 @@ inputs:
     type: string?
     default: |
       #!/bin/bash
+      set -e
       if [[ $0 == *.fasta ]] || [[ $0 == *.fa ]]; then
-          echo "Skipping"
+          echo "Skip extract step"
       elif [[ $0 == *.gz ]]; then
           gunzip -c $0 > "${0%%.*}".fa
           rm $0
@@ -37,7 +38,11 @@ inputs:
           rm $0
       fi
       if [ "$#" -ge 1 ]; then
-          samtools faidx "${0%%.*}".fa ${@:1} > t.fa
+          FILTER=${@:1}
+          FILTER=$( IFS=$','; echo "${FILTER[*]}" )
+          FILTER=(${FILTER//, / })
+          echo "Filtering by" ${FILTER[*]}
+          samtools faidx "${0%%.*}".fa ${FILTER[*]} > t.fa
           mv t.fa "${0%%.*}".fa
           rm "${0%%.*}".fa.fai
       fi
@@ -55,10 +60,11 @@ inputs:
   chr_list:
     type:
       - "null"
+      - string
       - string[]
     inputBinding:
       position: 8
-    doc: "List of the chromosomes to be included into the output file. Valid only for 2bit"
+    doc: "List of the chromosomes to be included into the output file. If pass as string, should be comma-separated"
 
 outputs:
 

--- a/workflows/genome-indices.cwl
+++ b/workflows/genome-indices.cwl
@@ -51,6 +51,11 @@ inputs:
       - string[]
     label: "Chromosome list to be included into the reference genome FASTA file"
     doc: "Filter chromosomes while extracting FASTA from 2bit"
+  
+  # chromosome_list:
+  #   type: string?
+  #   label: "Comma or space separated chromosome list to be used in indices"
+  #   doc: "Filter chromosomes while extracting FASTA from 2bit"
 
   effective_genome_size:
     type: string

--- a/workflows/genome-indices.cwl
+++ b/workflows/genome-indices.cwl
@@ -345,7 +345,7 @@ steps:
               FILTER=(${FILTER//, / })
               echo "Filtering by" ${FILTER[*]}
               cat refgene.txt | awk -v filter="$FILTER" 'BEGIN {split(filter, f); for (i in f) d[f[i]]} {if ($3 in d) print $0}' > refgene_filtered.txt  
-              mv refGene_filtered.txt refgene.txt
+              mv refgene_filtered.txt refgene.txt
             fi
             cut -f 2- refgene.txt | genePredToGtf file stdin refgene.gtf
             echo -e "bin\tname\tchrom\tstrand\ttxStart\ttxEnd\tcdsStart\tcdsEnd\texonCount\texonStarts\texonEnds\tscore\tname2\tcdsStartStat\tcdsEndStat\texonFrames" > refgene.tsv

--- a/workflows/genome-indices.cwl
+++ b/workflows/genome-indices.cwl
@@ -341,7 +341,9 @@ steps:
             gunzip $1 -c | grep -v "exonCount" | awk '{ if ($3=="chrM") print $0 }' >> refgene.txt
             if [ "$#" -ge 2 ]; then
               FILTER=${@:2}
-              echo "Filter refgene.txt to include only $FILTER"
+              FILTER=$( IFS=$','; echo "${FILTER[*]}" )
+              FILTER=(${FILTER//, / })
+              echo "Filtering by" ${FILTER[*]}
               cat refgene.txt | awk -v filter="$FILTER" 'BEGIN {split(filter, f); for (i in f) d[f[i]]} {if ($3 in d) print $0}' > refgene_filtered.txt  
               mv refGene_filtered.txt refgene.txt
             fi
@@ -361,6 +363,7 @@ steps:
         chromosome_list:
           type:
             - "null"
+            - string
             - string[]
           inputBinding:
             position: 8

--- a/workflows/genome-indices.cwl
+++ b/workflows/genome-indices.cwl
@@ -344,7 +344,7 @@ steps:
               FILTER=$( IFS=$','; echo "${FILTER[*]}" )
               FILTER=(${FILTER//, / })
               echo "Filtering by" ${FILTER[*]}
-              cat refgene.txt | awk -v filter="$FILTER" 'BEGIN {split(filter, f); for (i in f) d[f[i]]} {if ($3 in d) print $0}' > refgene_filtered.txt  
+              cat refgene.txt | awk -v filter="${FILTER[*]}" 'BEGIN {split(filter, f); for (i in f) d[f[i]]} {if ($3 in d) print $0}' > refgene_filtered.txt  
               mv refgene_filtered.txt refgene.txt
             fi
             cut -f 2- refgene.txt | genePredToGtf file stdin refgene.gtf


### PR DESCRIPTION
If you uncomment an alternative version of the input `chromosome_list` (see below), its value can be set in a string as a comma or space-separated list of chromosomes in a form of
`"chr1, chr2,   chr3      chrM"`

Uncomment this instead of current `chromosome_list` input, if necessary
```
  # chromosome_list:
  #   type: string?
  #   label: "Comma or space separated chromosome list to be used in indices"
  #   doc: "Filter chromosomes while extracting FASTA from 2bit"
```