### PR TITLE
Bypasses trimming adapter step if low read counts found

### DIFF
--- a/tests/conformance_tests.yaml
+++ b/tests/conformance_tests.yaml
@@ -726,8 +726,8 @@
     bam_statistics_report_after_filtering:
       location: upstream_bam_statistics_report_after_filtering.txt
       class: File
-    estimated_fragment_size: 160
-    mapped_reads_number: 23
+    estimated_fragment_size: 156
+    mapped_reads_number: 31
     insert_size_report_after_filtering:
       location: is_section.tsv
       class: File
@@ -899,8 +899,8 @@
     bam_statistics_report_after_filtering:
       location: upstream_bam_statistics_report_after_filtering.txt
       class: File
-    estimated_fragment_size: 160
-    mapped_reads_number: 23
+    estimated_fragment_size: 156
+    mapped_reads_number: 31
     insert_size_report_after_filtering:
       location: is_section.tsv
       class: File

--- a/tools/bypass-trimgalore-pe.cwl
+++ b/tools/bypass-trimgalore-pe.cwl
@@ -1,0 +1,166 @@
+cwlVersion: v1.0
+class: CommandLineTool
+
+
+hints:
+- class: DockerRequirement
+  dockerPull: scidap/scidap:v0.0.4
+
+
+inputs:
+
+  script:
+    type: string?
+    default: |
+      #!/bin/bash
+      ORIGINAL_FASTQ_1=$0
+      TRIMMED_FASTQ_1=$1
+      TRIMMING_REPORT_1=$2
+
+      ORIGINAL_FASTQ_2=$3
+      TRIMMED_FASTQ_2=$4
+      TRIMMING_REPORT_2=$5
+
+      MIN_COUNTS=$6
+      TRIMMED_COUNTS=$(( `cat $TRIMMED_FASTQ_1 | wc -l` / 4 )) 
+      
+      echo "ORIGINAL_FASTQ_1: ${ORIGINAL_FASTQ_1}"
+      echo "TRIMMED_FASTQ_1: ${TRIMMED_FASTQ_1}"
+      echo "TRIMMING_REPORT_1: ${TRIMMING_REPORT_1}"
+
+      echo "ORIGINAL_FASTQ_2: ${ORIGINAL_FASTQ_2}"
+      echo "TRIMMED_FASTQ_2: ${TRIMMED_FASTQ_2}"
+      echo "TRIMMING_REPORT_2: ${TRIMMING_REPORT_2}"
+
+      echo "TRIMMED_COUNTS: ${TRIMMED_COUNTS}"
+
+      if (( $TRIMMED_COUNTS < $MIN_COUNTS )); then
+        echo "Bypassing adapter trimming"
+        cp $ORIGINAL_FASTQ_1 `basename $TRIMMED_FASTQ_1`
+        cp $ORIGINAL_FASTQ_2 `basename $TRIMMED_FASTQ_2`
+      else
+        echo "Using adapter trimming results"
+        cp $TRIMMED_FASTQ_1 .
+        cp $TRIMMED_FASTQ_2 .
+        cp $TRIMMING_REPORT_1 .
+        cp $TRIMMING_REPORT_2 .
+      fi
+    inputBinding:
+      position: 5
+
+  original_fastq_file_1:
+    type: File
+    inputBinding:
+      position: 6
+
+  trimmed_fastq_file_1:
+    type: File
+    inputBinding:
+      position: 7
+
+  trimming_report_file_1:
+    type: File
+    inputBinding:
+      position: 8
+
+  original_fastq_file_2:
+    type: File
+    inputBinding:
+      position: 9
+
+  trimmed_fastq_file_2:
+    type: File
+    inputBinding:
+      position: 10
+
+  trimming_report_file_2:
+    type: File
+    inputBinding:
+      position: 11
+
+  min_reads_count:
+    type: int?
+    default: 100000
+    inputBinding:
+      position: 12
+
+
+outputs:
+
+  selected_fastq_file_1:
+    type: File
+    outputBinding:
+      glob: $(inputs.trimmed_fastq_file_1.basename)
+      
+  selected_report_file_1:
+    type: File?
+    outputBinding:
+      glob: $(inputs.trimming_report_file_1.basename)
+
+  selected_fastq_file_2:
+    type: File
+    outputBinding:
+      glob: $(inputs.trimmed_fastq_file_2.basename)
+      
+  selected_report_file_2:
+    type: File?
+    outputBinding:
+      glob: $(inputs.trimming_report_file_2.basename)
+
+
+baseCommand: ["bash", "-c"]
+
+
+$namespaces:
+  s: http://schema.org/
+
+$schemas:
+- http://schema.org/docs/schema_org_rdfa.html
+
+
+s:name: "bypass-trimgalore-pe"
+s:downloadUrl: https://raw.githubusercontent.com/Barski-lab/workflows/master/tools/bypass-trimgalore-pe.cwl
+s:codeRepository: https://github.com/Barski-lab/workflows
+s:license: http://www.apache.org/licenses/LICENSE-2.0
+
+s:isPartOf:
+  class: s:CreativeWork
+  s:name: Common Workflow Language
+  s:url: http://commonwl.org/
+
+s:creator:
+- class: s:Organization
+  s:legalName: "Cincinnati Children's Hospital Medical Center"
+  s:location:
+  - class: s:PostalAddress
+    s:addressCountry: "USA"
+    s:addressLocality: "Cincinnati"
+    s:addressRegion: "OH"
+    s:postalCode: "45229"
+    s:streetAddress: "3333 Burnet Ave"
+    s:telephone: "+1(513)636-4200"
+  s:logo: "https://www.cincinnatichildrens.org/-/media/cincinnati%20childrens/global%20shared/childrens-logo-new.png"
+  s:department:
+  - class: s:Organization
+    s:legalName: "Allergy and Immunology"
+    s:department:
+    - class: s:Organization
+      s:legalName: "Barski Research Lab"
+      s:member:
+      - class: s:Person
+        s:name: Michael Kotliar
+        s:email: mailto:misha.kotliar@gmail.com
+        s:sameAs:
+        - id: http://orcid.org/0000-0002-6486-3898
+
+doc: |
+  If the number of reads in the trimmed_fastq_file_1 is less then min_reads_count, tool
+  will return original_fastq_file_1/2 and nulls as selected_report_file_1/2. Otherwise,
+  the trimmed_fastq_file_1/2 and trimming_report_file_1/2 will be returned. Might be
+  usefull in case of trimgalore removed all reads from the original_fastq_file_1/2.
+
+s:about: |
+  If the number of reads in the trimmed_fastq_file_1 is less then min_reads_count, tool
+  will return original_fastq_file_1/2 and nulls as selected_report_file_1/2. Otherwise,
+  the trimmed_fastq_file_1/2 and trimming_report_file_1/2 will be returned. Might be
+  usefull in case of trimgalore removed all reads from the original_fastq_file_1/2.

--- a/tools/bypass-trimgalore-se.cwl
+++ b/tools/bypass-trimgalore-se.cwl
@@ -1,0 +1,128 @@
+cwlVersion: v1.0
+class: CommandLineTool
+
+
+hints:
+- class: DockerRequirement
+  dockerPull: scidap/scidap:v0.0.4
+
+
+inputs:
+
+  script:
+    type: string?
+    default: |
+      #!/bin/bash
+      ORIGINAL_FASTQ=$0
+      TRIMMED_FASTQ=$1
+      TRIMMING_REPORT=$2
+      MIN_COUNTS=$3
+      TRIMMED_COUNTS=$(( `cat $TRIMMED_FASTQ | wc -l` / 4 )) 
+      
+      echo "ORIGINAL_FASTQ: ${ORIGINAL_FASTQ}"
+      echo "TRIMMED_FASTQ: ${TRIMMED_FASTQ}"
+      echo "TRIMMING_REPORT: ${TRIMMING_REPORT}"
+      echo "TRIMMED_COUNTS: ${TRIMMED_COUNTS}"
+
+      if (( $TRIMMED_COUNTS < $MIN_COUNTS )); then
+        echo "Bypassing adapter trimming"
+        cp $ORIGINAL_FASTQ `basename $TRIMMED_FASTQ`
+      else
+        echo "Using adapter trimming results"
+        cp $TRIMMED_FASTQ .
+        cp $TRIMMING_REPORT .
+      fi
+    inputBinding:
+      position: 5
+
+  original_fastq_file:
+    type: File
+    inputBinding:
+      position: 6
+
+  trimmed_fastq_file:
+    type: File
+    inputBinding:
+      position: 7
+
+  trimming_report_file:
+    type: File
+    inputBinding:
+      position: 8
+
+  min_reads_count:
+    type: int?
+    default: 100000
+    inputBinding:
+      position: 9
+
+
+outputs:
+
+  selected_fastq_file:
+    type: File
+    outputBinding:
+      glob: $(inputs.trimmed_fastq_file.basename)
+      
+  selected_report_file:
+    type: File?
+    outputBinding:
+      glob: $(inputs.trimming_report_file.basename)
+
+
+baseCommand: ["bash", "-c"]
+
+
+$namespaces:
+  s: http://schema.org/
+
+$schemas:
+- http://schema.org/docs/schema_org_rdfa.html
+
+
+s:name: "bypass-trimgalore-se"
+s:downloadUrl: https://raw.githubusercontent.com/Barski-lab/workflows/master/tools/bypass-trimgalore-se.cwl
+s:codeRepository: https://github.com/Barski-lab/workflows
+s:license: http://www.apache.org/licenses/LICENSE-2.0
+
+s:isPartOf:
+  class: s:CreativeWork
+  s:name: Common Workflow Language
+  s:url: http://commonwl.org/
+
+s:creator:
+- class: s:Organization
+  s:legalName: "Cincinnati Children's Hospital Medical Center"
+  s:location:
+  - class: s:PostalAddress
+    s:addressCountry: "USA"
+    s:addressLocality: "Cincinnati"
+    s:addressRegion: "OH"
+    s:postalCode: "45229"
+    s:streetAddress: "3333 Burnet Ave"
+    s:telephone: "+1(513)636-4200"
+  s:logo: "https://www.cincinnatichildrens.org/-/media/cincinnati%20childrens/global%20shared/childrens-logo-new.png"
+  s:department:
+  - class: s:Organization
+    s:legalName: "Allergy and Immunology"
+    s:department:
+    - class: s:Organization
+      s:legalName: "Barski Research Lab"
+      s:member:
+      - class: s:Person
+        s:name: Michael Kotliar
+        s:email: mailto:misha.kotliar@gmail.com
+        s:sameAs:
+        - id: http://orcid.org/0000-0002-6486-3898
+
+doc: |
+  If the number of reads in the trimmed_fastq_file is less then min_reads_count, tool
+  will return original_fastq_file and null as selected_report_file. Otherwise, the
+  trimmed_fastq_file and trimming_report_file will be returned. Might be usefull in
+  case of trimgalore removed all reads from the original_fastq_file
+
+s:about: |
+  If the number of reads in the trimmed_fastq_file is less then min_reads_count, tool
+  will return original_fastq_file and null as selected_report_file. Otherwise, the
+  trimmed_fastq_file and trimming_report_file will be returned. Might be usefull in
+  case of trimgalore removed all reads from the original_fastq_file

--- a/workflows/trim-atacseq-pe.cwl
+++ b/workflows/trim-atacseq-pe.cwl
@@ -509,10 +509,27 @@ steps:
       - report_file
       - report_file_pair
 
+  bypass_trim:
+    run: ../tools/bypass-trimgalore-pe.cwl
+    in:
+      original_fastq_file_1: extract_fastq_upstream/fastq_file
+      trimmed_fastq_file_1: trim_fastq/trimmed_file
+      trimming_report_file_1: trim_fastq/report_file
+      original_fastq_file_2: extract_fastq_downstream/fastq_file
+      trimmed_fastq_file_2: trim_fastq/trimmed_file_pair
+      trimming_report_file_2: trim_fastq/report_file_pair
+      min_reads_count:
+        default: 100  # any small number should be good, as we are catching the case when trimgalore discarded all reads
+    out:
+      - selected_fastq_file_1
+      - selected_report_file_1
+      - selected_fastq_file_2
+      - selected_report_file_2
+
   rename_upstream:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file
+      source_file: bypass_trim/selected_fastq_file_1
       target_filename:
         source: extract_fastq_upstream/fastq_file
         valueFrom: $(self.basename)
@@ -522,7 +539,7 @@ steps:
   rename_downstream:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file_pair
+      source_file: bypass_trim/selected_fastq_file_2
       target_filename:
         source: extract_fastq_downstream/fastq_file
         valueFrom: $(self.basename)
@@ -681,8 +698,8 @@ steps:
   get_stat:
       run: ../tools/collect-statistics-chip-seq.cwl
       in:
-        trimgalore_report_fastq_1: trim_fastq/report_file
-        trimgalore_report_fastq_2: trim_fastq/report_file_pair
+        trimgalore_report_fastq_1: bypass_trim/selected_report_file_1
+        trimgalore_report_fastq_2: bypass_trim/selected_report_file_2
         bowtie_alignment_report: bowtie_aligner/log_file
         bam_statistics_report: get_bam_statistics/log_file
         bam_statistics_after_filtering_report: get_bam_statistics_after_filtering/log_file

--- a/workflows/trim-atacseq-se.cwl
+++ b/workflows/trim-atacseq-se.cwl
@@ -446,10 +446,22 @@ steps:
       - trimmed_file
       - report_file
 
+  bypass_trim:
+    run: ../tools/bypass-trimgalore-se.cwl
+    in:
+      original_fastq_file: extract_fastq/fastq_file
+      trimmed_fastq_file: trim_fastq/trimmed_file
+      trimming_report_file: trim_fastq/report_file
+      min_reads_count:
+        default: 100  # any small number should be good, as we are catching the case when trimgalore discarded all reads
+    out:
+      - selected_fastq_file
+      - selected_report_file
+
   rename:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file
+      source_file: bypass_trim/selected_fastq_file
       target_filename:
         source: extract_fastq/fastq_file
         valueFrom: $(self.basename)
@@ -601,7 +613,7 @@ steps:
   get_stat:
       run: ../tools/collect-statistics-chip-seq.cwl
       in:
-        trimgalore_report_fastq_1: trim_fastq/report_file
+        trimgalore_report_fastq_1: bypass_trim/selected_report_file
         bowtie_alignment_report: bowtie_aligner/log_file
         bam_statistics_report: get_bam_statistics/log_file
         bam_statistics_after_filtering_report: get_bam_statistics_after_filtering/log_file

--- a/workflows/trim-chipseq-pe.cwl
+++ b/workflows/trim-chipseq-pe.cwl
@@ -501,10 +501,27 @@ steps:
       - report_file
       - report_file_pair
 
+  bypass_trim:
+    run: ../tools/bypass-trimgalore-pe.cwl
+    in:
+      original_fastq_file_1: extract_fastq_upstream/fastq_file
+      trimmed_fastq_file_1: trim_fastq/trimmed_file
+      trimming_report_file_1: trim_fastq/report_file
+      original_fastq_file_2: extract_fastq_downstream/fastq_file
+      trimmed_fastq_file_2: trim_fastq/trimmed_file_pair
+      trimming_report_file_2: trim_fastq/report_file_pair
+      min_reads_count:
+        default: 100  # any small number should be good, as we are catching the case when trimgalore discarded all reads
+    out:
+      - selected_fastq_file_1
+      - selected_report_file_1
+      - selected_fastq_file_2
+      - selected_report_file_2
+
   rename_upstream:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file
+      source_file: bypass_trim/selected_fastq_file_1
       target_filename:
         source: extract_fastq_upstream/fastq_file
         valueFrom: $(self.basename)
@@ -514,7 +531,7 @@ steps:
   rename_downstream:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file_pair
+      source_file: bypass_trim/selected_fastq_file_2
       target_filename:
         source: extract_fastq_downstream/fastq_file
         valueFrom: $(self.basename)
@@ -666,8 +683,8 @@ steps:
   get_stat:
       run: ../tools/collect-statistics-chip-seq.cwl
       in:
-        trimgalore_report_fastq_1: trim_fastq/report_file
-        trimgalore_report_fastq_2: trim_fastq/report_file_pair
+        trimgalore_report_fastq_1: bypass_trim/selected_report_file_1
+        trimgalore_report_fastq_2: bypass_trim/selected_report_file_2
         bowtie_alignment_report: bowtie_aligner/log_file
         bam_statistics_report: get_bam_statistics/log_file
         bam_statistics_after_filtering_report: get_bam_statistics_after_filtering/log_file

--- a/workflows/trim-chipseq-se.cwl
+++ b/workflows/trim-chipseq-se.cwl
@@ -438,10 +438,22 @@ steps:
       - trimmed_file
       - report_file
 
+  bypass_trim:
+    run: ../tools/bypass-trimgalore-se.cwl
+    in:
+      original_fastq_file: extract_fastq/fastq_file
+      trimmed_fastq_file: trim_fastq/trimmed_file
+      trimming_report_file: trim_fastq/report_file
+      min_reads_count:
+        default: 100  # any small number should be good, as we are catching the case when trimgalore discarded all reads
+    out:
+      - selected_fastq_file
+      - selected_report_file
+
   rename:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file
+      source_file: bypass_trim/selected_fastq_file
       target_filename:
         source: extract_fastq/fastq_file
         valueFrom: $(self.basename)
@@ -585,7 +597,7 @@ steps:
   get_stat:
       run: ../tools/collect-statistics-chip-seq.cwl
       in:
-        trimgalore_report_fastq_1: trim_fastq/report_file
+        trimgalore_report_fastq_1: bypass_trim/selected_report_file
         bowtie_alignment_report: bowtie_aligner/log_file
         bam_statistics_report: get_bam_statistics/log_file
         bam_statistics_after_filtering_report: get_bam_statistics_after_filtering/log_file

--- a/workflows/trim-rnaseq-pe-dutp.cwl
+++ b/workflows/trim-rnaseq-pe-dutp.cwl
@@ -359,10 +359,27 @@ steps:
       - report_file
       - report_file_pair
 
+  bypass_trim:
+    run: ../tools/bypass-trimgalore-pe.cwl
+    in:
+      original_fastq_file_1: extract_fastq_upstream/fastq_file
+      trimmed_fastq_file_1: trim_fastq/trimmed_file
+      trimming_report_file_1: trim_fastq/report_file
+      original_fastq_file_2: extract_fastq_downstream/fastq_file
+      trimmed_fastq_file_2: trim_fastq/trimmed_file_pair
+      trimming_report_file_2: trim_fastq/report_file_pair
+      min_reads_count:
+        default: 100  # any small number should be good, as we are catching the case when trimgalore discarded all reads
+    out:
+      - selected_fastq_file_1
+      - selected_report_file_1
+      - selected_fastq_file_2
+      - selected_report_file_2
+
   rename_upstream:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file
+      source_file: bypass_trim/selected_fastq_file_1
       target_filename:
         source: extract_fastq_upstream/fastq_file
         valueFrom: $(self.basename)
@@ -372,7 +389,7 @@ steps:
   rename_downstream:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file_pair
+      source_file: bypass_trim/selected_fastq_file_2
       target_filename:
         source: extract_fastq_downstream/fastq_file
         valueFrom: $(self.basename)
@@ -520,8 +537,8 @@ steps:
   get_stat:
       run: ../tools/collect-statistics-rna-seq.cwl
       in:
-        trimgalore_report_fastq_1: trim_fastq/report_file
-        trimgalore_report_fastq_2: trim_fastq/report_file_pair
+        trimgalore_report_fastq_1: bypass_trim/selected_report_file_1
+        trimgalore_report_fastq_2: bypass_trim/selected_report_file_2
         star_alignment_report: star_aligner/log_final
         bowtie_alignment_report: bowtie_aligner/log_file
         bam_statistics_report: get_bam_statistics/log_file

--- a/workflows/trim-rnaseq-pe.cwl
+++ b/workflows/trim-rnaseq-pe.cwl
@@ -343,10 +343,27 @@ steps:
       - report_file
       - report_file_pair
 
+  bypass_trim:
+    run: ../tools/bypass-trimgalore-pe.cwl
+    in:
+      original_fastq_file_1: extract_fastq_upstream/fastq_file
+      trimmed_fastq_file_1: trim_fastq/trimmed_file
+      trimming_report_file_1: trim_fastq/report_file
+      original_fastq_file_2: extract_fastq_downstream/fastq_file
+      trimmed_fastq_file_2: trim_fastq/trimmed_file_pair
+      trimming_report_file_2: trim_fastq/report_file_pair
+      min_reads_count:
+        default: 100  # any small number should be good, as we are catching the case when trimgalore discarded all reads
+    out:
+      - selected_fastq_file_1
+      - selected_report_file_1
+      - selected_fastq_file_2
+      - selected_report_file_2
+
   rename_upstream:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file
+      source_file: bypass_trim/selected_fastq_file_1
       target_filename:
         source: extract_fastq_upstream/fastq_file
         valueFrom: $(self.basename)
@@ -356,7 +373,7 @@ steps:
   rename_downstream:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file_pair
+      source_file: bypass_trim/selected_fastq_file_2
       target_filename:
         source: extract_fastq_downstream/fastq_file
         valueFrom: $(self.basename)
@@ -468,8 +485,8 @@ steps:
   get_stat:
       run: ../tools/collect-statistics-rna-seq.cwl
       in:
-        trimgalore_report_fastq_1: trim_fastq/report_file
-        trimgalore_report_fastq_2: trim_fastq/report_file_pair
+        trimgalore_report_fastq_1: bypass_trim/selected_report_file_1
+        trimgalore_report_fastq_2: bypass_trim/selected_report_file_2
         star_alignment_report: star_aligner/log_final
         bowtie_alignment_report: bowtie_aligner/log_file
         bam_statistics_report: get_bam_statistics/log_file

--- a/workflows/trim-rnaseq-se-dutp.cwl
+++ b/workflows/trim-rnaseq-se-dutp.cwl
@@ -292,10 +292,22 @@ steps:
       - trimmed_file
       - report_file
 
+  bypass_trim:
+    run: ../tools/bypass-trimgalore-se.cwl
+    in:
+      original_fastq_file: extract_fastq/fastq_file
+      trimmed_fastq_file: trim_fastq/trimmed_file
+      trimming_report_file: trim_fastq/report_file
+      min_reads_count:
+        default: 100  # any small number should be good, as we are catching the case when trimgalore discarded all reads
+    out:
+      - selected_fastq_file
+      - selected_report_file
+
   rename:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file
+      source_file: bypass_trim/selected_fastq_file
       target_filename:
         source: extract_fastq/fastq_file
         valueFrom: $(self.basename)
@@ -434,7 +446,7 @@ steps:
   get_stat:
       run: ../tools/collect-statistics-rna-seq.cwl
       in:
-        trimgalore_report_fastq_1: trim_fastq/report_file
+        trimgalore_report_fastq_1: bypass_trim/selected_report_file
         star_alignment_report: star_aligner/log_final
         bowtie_alignment_report: bowtie_aligner/log_file
         bam_statistics_report: get_bam_statistics/log_file

--- a/workflows/trim-rnaseq-se.cwl
+++ b/workflows/trim-rnaseq-se.cwl
@@ -281,10 +281,22 @@ steps:
       - trimmed_file
       - report_file
 
+  bypass_trim:
+    run: ../tools/bypass-trimgalore-se.cwl
+    in:
+      original_fastq_file: extract_fastq/fastq_file
+      trimmed_fastq_file: trim_fastq/trimmed_file
+      trimming_report_file: trim_fastq/report_file
+      min_reads_count:
+        default: 100  # any small number should be good, as we are catching the case when trimgalore discarded all reads
+    out:
+      - selected_fastq_file
+      - selected_report_file
+
   rename:
     run: ../tools/rename.cwl
     in:
-      source_file: trim_fastq/trimmed_file
+      source_file: bypass_trim/selected_fastq_file
       target_filename:
         source: extract_fastq/fastq_file
         valueFrom: $(self.basename)
@@ -392,7 +404,7 @@ steps:
   get_stat:
       run: ../tools/collect-statistics-rna-seq.cwl
       in:
-        trimgalore_report_fastq_1: trim_fastq/report_file
+        trimgalore_report_fastq_1: bypass_trim/selected_report_file
         star_alignment_report: star_aligner/log_final
         bowtie_alignment_report: bowtie_aligner/log_file
         bam_statistics_report: get_bam_statistics/log_file


### PR DESCRIPTION
Fixes the problem of having an empty FASTQ files after adapter trimming filtering step. When TrimGalore is run (the tool used for adapter trimming), it discards all reads shorter than 30 bp thus sometimes filtering out all of the reads. To prevent the workflows from failing when working with empty files, we added the `bypass_trim` step that checks if the filtered FASTQ file became empty (less than 100 reads). In case the filtered FASTQ file is empty, `bypass_trim` step will pass the original (not filtered) FASTQ file to the next steps. Also, in this case the generated Markdown report won't have `adapter trimming statistics` section.

Patch was applied to the main workflows we use:
- trim-atacseq-pe.cwl
- trim-atacseq-se.cwl
- trim-chipseq-pe.cwl
- trim-chipseq-se.cwl
- trim-rnaseq-pe-dutp.cwl
- trim-rnaseq-pe.cwl
- trim-rnaseq-se-dutp.cwl
- trim-rnaseq-se.cwl

Workflows that may have similar problems but were excluded from update as no tests found:
- clipseq-se.cwl
- trim-quantseq-mrnaseq-se.cwl
- trim-rnaseq-pe-smarter-dutp.cwl