### PR TITLE
Add IGV tracks to the Bismark outputs (tested with 1M reads files)

### DIFF
--- a/tools/python-get-stat-bismark.cwl
+++ b/tools/python-get-stat-bismark.cwl
@@ -3,6 +3,7 @@ class: CommandLineTool
 
 
 requirements:
+- class: InlineJavascriptRequirement
 - class: DockerRequirement
   dockerPull: biowardrobe2/scidap:v0.0.3
 
@@ -66,6 +67,14 @@ outputs:
   collected_report_formatted:
     type: stdout
     doc: "Combined Bismark alignment and splitting reports"
+
+  mapped_reads:
+    type: int
+    outputBinding:
+      loadContents: true
+      glob: "collected_report_formatted.tsv"
+      outputEval: $(parseInt(self[0].contents.split('\n')[1].split('\t')[1]))
+
 
 stdout: "collected_report_formatted.tsv"
 baseCommand: [python, '-c']

--- a/workflows/bismark-methylation-pe.cwl
+++ b/workflows/bismark-methylation-pe.cwl
@@ -49,6 +49,22 @@ outputs:
     format: "http://edamontology.org/format_2572"
     outputSource: bismark_align/bam_file
 
+  bambai_pair:
+    type: File
+    label: "BAM alignment and BAI index files"
+    doc: "Bismark generated coordinate sorted BAM alignment and BAI index files"
+    format: "http://edamontology.org/format_2572"
+    outputSource: samtools_sort_index/bam_bai_pair
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        optional: true
+        type: 'alignment'
+        format: 'bam'
+        name: "BAM Track"
+        displayMode: "SQUISHED"
+
   bismark_alignment_report:
     type: File
     label: "Bismark alignment and methylation report"
@@ -100,13 +116,14 @@ outputs:
     doc: "Coverage text file summarising cytosine methylation values in bedGraph format (tab-delimited; 0-based start coords, 1-based end coords)"
     format: "http://edamontology.org/format_3583"
     outputSource: bismark_extract_methylation/bedgraph_coverage_file
-    # 'sd:visualPlugins':
-    # - igvbrowser:
-    #     tab: 'IGV Genome Browser'
-    #     id: 'igvbrowser'
-    #     type: 'annotation'
-    #     name: "Methylation statuses"
-    #     height: 120
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        type: 'annotation'
+        name: "Methylation statuses"
+        displayMode: "COLLAPSE"
+        height: 120
 
   bismark_coverage_file:
     type: File
@@ -245,6 +262,14 @@ steps:
       alignment_report: bismark_align/alignment_report
       splitting_report: bismark_extract_methylation/splitting_report
     out: [collected_report_formatted]
+
+  samtools_sort_index:
+    run: ../tools/samtools-sort-index.cwl
+    in:
+      sort_input: bismark_align/bam_file
+      threads: threads
+    out: [bam_bai_pair]
+
 
 $namespaces:
   s: http://schema.org/

--- a/workflows/bismark-methylation-pe.cwl
+++ b/workflows/bismark-methylation-pe.cwl
@@ -358,7 +358,7 @@ steps:
       input_file: bismark_extract_methylation/bedgraph_coverage_file
       script:
         default: |
-          zcat "$0" > methylation_statuses.bedGraph
+          zcat "$0" | grep -v "track" > methylation_statuses.bedGraph
     out: [output_file]
 
   sort_bed:

--- a/workflows/bismark-methylation-pe.cwl
+++ b/workflows/bismark-methylation-pe.cwl
@@ -148,10 +148,14 @@ outputs:
 
   collected_report:
     type: File
-    label: "HTML report page"
+    label: "Bismark Processing Report"
     doc: "Bismark generated graphical HTML report page"
     format: "http://edamontology.org/format_2331"
     outputSource: bismark_report/collected_report
+    'sd:visualPlugins':
+    - linkList:
+        tab: 'Overview'
+        target: "_blank"
 
   collected_report_formatted:
     type: File
@@ -267,6 +271,8 @@ steps:
     run: ../tools/samtools-sort-index.cwl
     in:
       sort_input: bismark_align/bam_file
+      sort_output_filename:
+        default: "sorted_alignments.bam"
       threads: threads
     out: [bam_bai_pair]
 

--- a/workflows/bismark-methylation-se.cwl
+++ b/workflows/bismark-methylation-se.cwl
@@ -43,6 +43,22 @@ outputs:
     format: "http://edamontology.org/format_2572"
     outputSource: bismark_align/bam_file
 
+  bambai_pair:
+    type: File
+    label: "BAM alignment and BAI index files"
+    doc: "Bismark generated coordinate sorted BAM alignment and BAI index files"
+    format: "http://edamontology.org/format_2572"
+    outputSource: samtools_sort_index/bam_bai_pair
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        optional: true
+        type: 'alignment'
+        format: 'bam'
+        name: "BAM Track"
+        displayMode: "SQUISHED"
+
   bismark_alignment_report:
     type: File
     label: "Bismark alignment and methylation report"
@@ -94,13 +110,14 @@ outputs:
     doc: "Coverage text file summarising cytosine methylation values in bedGraph format (tab-delimited; 0-based start coords, 1-based end coords)"
     format: "http://edamontology.org/format_3583"
     outputSource: bismark_extract_methylation/bedgraph_coverage_file
-    # 'sd:visualPlugins':
-    # - igvbrowser:
-    #     tab: 'IGV Genome Browser'
-    #     id: 'igvbrowser'
-    #     type: 'annotation'
-    #     name: "Methylation statuses"
-    #     height: 120
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        type: 'annotation'
+        name: "Methylation statuses"
+        displayMode: "COLLAPSE"
+        height: 40
 
   bismark_coverage_file:
     type: File
@@ -217,6 +234,14 @@ steps:
       alignment_report: bismark_align/alignment_report
       splitting_report: bismark_extract_methylation/splitting_report
     out: [collected_report_formatted]
+
+  samtools_sort_index:
+    run: ../tools/samtools-sort-index.cwl
+    in:
+      sort_input: bismark_align/bam_file
+      threads: threads
+    out: [bam_bai_pair]
+
 
 $namespaces:
   s: http://schema.org/

--- a/workflows/bismark-methylation-se.cwl
+++ b/workflows/bismark-methylation-se.cwl
@@ -2,6 +2,14 @@ cwlVersion: v1.0
 class: Workflow
 
 
+requirements:
+  - class: SubworkflowFeatureRequirement
+  - class: ScatterFeatureRequirement
+  - class: StepInputExpressionRequirement
+  - class: MultipleInputFeatureRequirement
+  - class: InlineJavascriptRequirement
+
+
 'sd:upstream':
   genome:
     - "bismark-index.cwl"
@@ -59,6 +67,20 @@ outputs:
         name: "BAM Track"
         displayMode: "SQUISHED"
 
+  bigwig_file:
+    type: File
+    format: "http://edamontology.org/format_3006"
+    label: "BigWig file"
+    doc: "Generated BigWig file"
+    outputSource: bam_to_bigwig/bigwig_file
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        type: 'wig'
+        name: "BigWig Track"
+        height: 120
+
   bismark_alignment_report:
     type: File
     label: "Bismark alignment and methylation report"
@@ -110,13 +132,28 @@ outputs:
     doc: "Coverage text file summarising cytosine methylation values in bedGraph format (tab-delimited; 0-based start coords, 1-based end coords)"
     format: "http://edamontology.org/format_3583"
     outputSource: bismark_extract_methylation/bedgraph_coverage_file
+    # 'sd:visualPlugins':
+    # - igvbrowser:
+    #     tab: 'IGV Genome Browser'
+    #     id: 'igvbrowser'
+    #     type: 'annotation'
+    #     name: "Methylation statuses"
+    #     displayMode: "COLLAPSE"
+    #     height: 40
+
+  bigbed_coverage_file:
+    type: File
+    label: "Methylation statuses bigBed coverage file"
+    doc: "Coverage text file summarising cytosine methylation values in bedGraph format (tab-delimited; 0-based start coords, 1-based end coords)"
+    format: "http://edamontology.org/format_3004"
+    outputSource: bed_to_bigbed/bigbed_file
     'sd:visualPlugins':
     - igvbrowser:
         tab: 'IGV Genome Browser'
         id: 'igvbrowser'
         type: 'annotation'
+        format: 'bigbed'
         name: "Methylation statuses"
-        displayMode: "COLLAPSE"
         height: 40
 
   bismark_coverage_file:
@@ -237,7 +274,7 @@ steps:
     in:
       alignment_report: bismark_align/alignment_report
       splitting_report: bismark_extract_methylation/splitting_report
-    out: [collected_report_formatted]
+    out: [collected_report_formatted, mapped_reads]
 
   samtools_sort_index:
     run: ../tools/samtools-sort-index.cwl
@@ -247,6 +284,72 @@ steps:
         default: "sorted_alignments.bam"
       threads: threads
     out: [bam_bai_pair]
+
+  get_chr_name_length:
+    run:
+      cwlVersion: v1.0
+      class: CommandLineTool
+      hints:
+      - class: DockerRequirement
+        dockerPull: biowardrobe2/samtools:v1.4
+      inputs:
+        script:
+          type: string?
+          default: |
+            #!/bin/bash
+            samtools view -H "$0" |  grep SN | cut -f 2,3 | tr -d "SN:" | tr -d "LN:"
+          inputBinding:
+            position: 5
+        bam_bai_pair:
+          type: File
+          inputBinding:
+            position: 6
+      outputs:
+        chrom_length_file:
+          type: stdout
+      baseCommand: ["bash", "-c"]
+      stdout: "chrom_length_file.tsv"
+    in:
+      bam_bai_pair: samtools_sort_index/bam_bai_pair
+    out:
+    - chrom_length_file
+
+  bam_to_bigwig:
+    run: ../tools/bam-bedgraph-bigwig.cwl
+    in:
+      bam_file: samtools_sort_index/bam_bai_pair
+      chrom_length_file: get_chr_name_length/chrom_length_file
+      mapped_reads_number: format_bismark_report/mapped_reads
+    out: [bigwig_file]
+
+  extract_bed:
+    run: ../tools/custom-bash.cwl
+    in:
+      input_file: bismark_extract_methylation/bedgraph_coverage_file
+      script:
+        default: |
+          zcat "$0" > methylation_statuses.bedGraph
+    out: [output_file]
+
+  sort_bed:
+    run: ../tools/linux-sort.cwl
+    in:
+      unsorted_file: extract_bed/output_file
+      key:
+        default: ["1,1","2,2n"]
+    out: [sorted_file]
+
+  bed_to_bigbed:
+    run: ../tools/ucsc-bedtobigbed.cwl
+    in:
+      input_bed: sort_bed/sorted_file
+      bed_type:
+        default: "bed4"
+      chrom_length_file: get_chr_name_length/chrom_length_file
+      output_filename:
+        source: sort_bed/sorted_file
+        valueFrom: $(self.basename.split('.').slice(0,-1).join('.') + ".bigBed")
+    out: [bigbed_file]
 
 
 $namespaces:

--- a/workflows/bismark-methylation-se.cwl
+++ b/workflows/bismark-methylation-se.cwl
@@ -142,10 +142,14 @@ outputs:
 
   collected_report:
     type: File
-    label: "HTML report page"
+    label: "Bismark Processing Report"
     doc: "Bismark generated graphical HTML report page"
     format: "http://edamontology.org/format_2331"
     outputSource: bismark_report/collected_report
+    'sd:visualPlugins':
+    - linkList:
+        tab: 'Overview'
+        target: "_blank"
 
   collected_report_formatted:
     type: File
@@ -239,6 +243,8 @@ steps:
     run: ../tools/samtools-sort-index.cwl
     in:
       sort_input: bismark_align/bam_file
+      sort_output_filename:
+        default: "sorted_alignments.bam"
       threads: threads
     out: [bam_bai_pair]
 

--- a/workflows/bismark-methylation-se.cwl
+++ b/workflows/bismark-methylation-se.cwl
@@ -328,7 +328,7 @@ steps:
       input_file: bismark_extract_methylation/bedgraph_coverage_file
       script:
         default: |
-          zcat "$0" > methylation_statuses.bedGraph
+          zcat "$0" | grep -v "track" > methylation_statuses.bedGraph
     out: [output_file]
 
   sort_bed:


### PR DESCRIPTION
Added also bigwig and bigbed tracks, but it looks like the BAM file is the most important in this analysis.