### PR TITLE
Updated Bismark indices to produce IGV related outputs. Not tested

### DIFF
--- a/workflows/bismark-methylation-pe.cwl
+++ b/workflows/bismark-methylation-pe.cwl
@@ -11,7 +11,7 @@ requirements:
 
 
 'sd:upstream':
-  genome:
+  genome_indices:
     - "bismark-index.cwl"
 
 
@@ -37,7 +37,14 @@ inputs:
     type: Directory
     label: "Bismark indices folder"
     doc: "Path to Bismark generated indices folder"
-    'sd:upstreamSource': "genome/indices_folder"
+    'sd:upstreamSource': "genome_indices/indices_folder"
+
+  chrom_length:
+    type: File
+    format: "http://edamontology.org/format_2330"
+    label: "Chromosomes length file"
+    doc: "Chromosomes length file"
+    'sd:upstreamSource': "genome_indices/chrom_length"
 
   threads:
     type: int?
@@ -302,35 +309,6 @@ steps:
       threads: threads
     out: [bam_bai_pair]
 
-  get_chr_name_length:
-    run:
-      cwlVersion: v1.0
-      class: CommandLineTool
-      hints:
-      - class: DockerRequirement
-        dockerPull: biowardrobe2/samtools:v1.4
-      inputs:
-        script:
-          type: string?
-          default: |
-            #!/bin/bash
-            samtools view -H "$0" |  grep SN | cut -f 2,3 | tr -d "SN:" | tr -d "LN:"
-          inputBinding:
-            position: 5
-        bam_bai_pair:
-          type: File
-          inputBinding:
-            position: 6
-      outputs:
-        chrom_length_file:
-          type: stdout
-      baseCommand: ["bash", "-c"]
-      stdout: "chrom_length_file.tsv"
-    in:
-      bam_bai_pair: samtools_sort_index/bam_bai_pair
-    out:
-    - chrom_length_file
-
   extract_bed:
     run: ../tools/custom-bash.cwl
     in:
@@ -354,7 +332,7 @@ steps:
       input_bed: sort_bed/sorted_file
       bed_type:
         default: "bed4"
-      chrom_length_file: get_chr_name_length/chrom_length_file
+      chrom_length_file: chrom_length
       output_filename:
         source: sort_bed/sorted_file
         valueFrom: $(self.basename.split('.').slice(0,-1).join('.') + ".bigBed")

--- a/workflows/bismark-methylation-se.cwl
+++ b/workflows/bismark-methylation-se.cwl
@@ -11,7 +11,7 @@ requirements:
 
 
 'sd:upstream':
-  genome:
+  genome_indices:
     - "bismark-index.cwl"
 
 
@@ -31,7 +31,14 @@ inputs:
     type: Directory
     label: "Bismark indices folder"
     doc: "Path to Bismark generated indices folder"
-    'sd:upstreamSource': "genome/indices_folder"
+    'sd:upstreamSource': "genome_indices/indices_folder"
+
+  chrom_length:
+    type: File
+    format: "http://edamontology.org/format_2330"
+    label: "Chromosomes length file"
+    doc: "Chromosomes length file"
+    'sd:upstreamSource': "genome_indices/chrom_length"
 
   threads:
     type: int?
@@ -272,35 +279,6 @@ steps:
       threads: threads
     out: [bam_bai_pair]
 
-  get_chr_name_length:
-    run:
-      cwlVersion: v1.0
-      class: CommandLineTool
-      hints:
-      - class: DockerRequirement
-        dockerPull: biowardrobe2/samtools:v1.4
-      inputs:
-        script:
-          type: string?
-          default: |
-            #!/bin/bash
-            samtools view -H "$0" |  grep SN | cut -f 2,3 | tr -d "SN:" | tr -d "LN:"
-          inputBinding:
-            position: 5
-        bam_bai_pair:
-          type: File
-          inputBinding:
-            position: 6
-      outputs:
-        chrom_length_file:
-          type: stdout
-      baseCommand: ["bash", "-c"]
-      stdout: "chrom_length_file.tsv"
-    in:
-      bam_bai_pair: samtools_sort_index/bam_bai_pair
-    out:
-    - chrom_length_file
-
   extract_bed:
     run: ../tools/custom-bash.cwl
     in:
@@ -324,7 +302,7 @@ steps:
       input_bed: sort_bed/sorted_file
       bed_type:
         default: "bed4"
-      chrom_length_file: get_chr_name_length/chrom_length_file
+      chrom_length_file: chrom_length
       output_filename:
         source: sort_bed/sorted_file
         valueFrom: $(self.basename.split('.').slice(0,-1).join('.') + ".bigBed")


### PR DESCRIPTION
]Added inputs:
- chrom_sizes
- annotation_tab
- mitochondrial_annotation_tab
- cytoband

Added outputs:
- annotation
- annotation_bed
- annotation_bed_tbi
- fasta_output
- fasta_fai_output
- cytoband_output

Job template for mm10 should be updated with the following fields:
```
  chrom_sizes: {
      location: 'https://hgdownload.soe.ucsc.edu/goldenPath/mm10/bigZips/mm10.chrom.sizes',
      token: ''
  }
  annotation_tab: {
      location: 'https://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/refGene.txt.gz',
      token: ''
  },
  mitochondrial_annotation_tab: {
      location: 'https://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/wgEncodeGencodeBasicVM18.txt.gz',
      token: ''
  },
  cytoband: {
      location: 'https://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/cytoBandIdeo.txt.gz',
      token: ''
  }
```

Job template for hg38 should be updated with the following fields:
```
  chrom_sizes: {
      location: 'https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.chrom.sizes',
      token: ''
  }
  annotation_tab: {
      location: 'https://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/refGene.txt.gz',
      token: ''
  },
  mitochondrial_annotation_tab: {
      location: 'https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/wgEncodeGencodeBasicV28.txt.gz',
      token: ''
  },
  cytoband: {
      location: 'https://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/cytoBandIdeo.txt.gz',
      token: ''
  }
```