### PR TITLE
Updated Bismark pipelines to produce bigWig instead of bigBed. Tested on 1M reads file

### DIFF
--- a/run_test_docker.sh
+++ b/run_test_docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-UBUNTU_VERSION=${1:-"18.04"}
-PYTHON_VERSION=${2:-"3.6.0"}
+UBUNTU_VERSION=${1:-"20.04"}
+PYTHON_VERSION=${2:-"3.8.10"}
 CWLTOOL_VERSION=${3:-"main"}
 CWLTEST_VERSION=${4:-"main"}
 

--- a/workflows/bismark-methylation-se.cwl
+++ b/workflows/bismark-methylation-se.cwl
@@ -27,8 +27,8 @@ inputs:
     - type: array
       items: File
     format: "http://edamontology.org/format_1930"
-    label: "FASTQ file"
-    doc: "Uncompressed or gzipped FASTQ file, single-end"
+    label: "FASTQ file(s)"
+    doc: "Uncompressed or gzipped FASTQ file(s), single-end"
 
   indices_folder:
     type: Directory
@@ -138,20 +138,19 @@ outputs:
     #     displayMode: "COLLAPSE"
     #     height: 40
 
-  bigbed_coverage_file:
+  bigwig_coverage_file:
     type: File
-    label: "Methylation statuses bigBed coverage file"
-    doc: "Coverage text file summarising cytosine methylation values in bedGraph format (tab-delimited; 0-based start coords, 1-based end coords)"
-    format: "http://edamontology.org/format_3004"
-    outputSource: bed_to_bigbed/bigbed_file
+    label: "Methylation statuses bigWig coverage file"
+    doc: "Coverage text file summarising cytosine methylation values in bigWig format (tab-delimited; 0-based start coords, 1-based end coords)"
+    format: "http://edamontology.org/format_3006"
+    outputSource: sorted_bedgraph_to_bigwig/bigwig_file
     'sd:visualPlugins':
     - igvbrowser:
         tab: 'IGV Genome Browser'
         id: 'igvbrowser'
-        type: 'annotation'
-        format: 'bigbed'
+        type: 'wig'
         name: "Methylation statuses"
-        height: 40
+        height: 120
 
   bismark_coverage_file:
     type: File
@@ -215,6 +214,8 @@ steps:
     run: ../tools/extract-fastq.cwl
     in:
       compressed_file: fastq_file_r1
+      output_prefix:
+        default: "read_1"
     out:
     - fastq_file
 
@@ -282,7 +283,7 @@ steps:
       threads: threads
     out: [bam_bai_pair]
 
-  extract_bed:
+  remove_metadata:
     run: ../tools/custom-bash.cwl
     in:
       input_file: bismark_extract_methylation/bedgraph_coverage_file
@@ -291,25 +292,24 @@ steps:
           zcat "$0" | grep -v "track" > methylation_statuses.bedGraph
     out: [output_file]
 
-  sort_bed:
+  sort_bedgraph:
     run: ../tools/linux-sort.cwl
     in:
-      unsorted_file: extract_bed/output_file
+      unsorted_file: remove_metadata/output_file
       key:
         default: ["1,1","2,2n"]
     out: [sorted_file]
 
-  bed_to_bigbed:
-    run: ../tools/ucsc-bedtobigbed.cwl
+  sorted_bedgraph_to_bigwig:
+    run: ../tools/ucsc-bedgraphtobigwig.cwl
     in:
-      input_bed: sort_bed/sorted_file
-      bed_type:
-        default: "bed4"
+      bedgraph_file: sort_bedgraph/sorted_file
       chrom_length_file: chrom_length
       output_filename:
-        source: sort_bed/sorted_file
-        valueFrom: $(self.basename.split('.').slice(0,-1).join('.') + ".bigBed")
-    out: [bigbed_file]
+        source: sort_bedgraph/sorted_file
+        valueFrom: $(self.basename.split('.').slice(0,-1).join('.') + ".bigWig")
+    out: [bigwig_file]
+
 
 
 $namespaces:


### PR DESCRIPTION
Showing results in bigBed format flattens all the "peaks"