### PR TITLE
SDAP-1207 homer upstream input updates

### DIFF
--- a/dockerfiles/scripts/run_kraken2pe.sh
+++ b/dockerfiles/scripts/run_kraken2pe.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 
-#   NOT CURRENTLY IN USE
+#   NOT CURRENTLY IN USE (rolled up into the cwl tool)
 #   Shell wrapper for run_kraken2pe.sh
 #
 ##########################################################################################
-#
-# v0.0.1
-# - format input lists for rnbeads in Rscript
-# - run rnbeads Rscript
-##########################################################################################
-printf "$(date)\nLog file for run_rnbeads_diff.sh\n\n"
+printf "$(date)\nLog file for run_kraken2pe.sh\n\n"
 
 
 #	FUNCTIONS
@@ -17,7 +12,7 @@ printf "$(date)\nLog file for run_rnbeads_diff.sh\n\n"
 usage()
 {
 cat << EOF
-Help message for \`run_rnbeads_diff.sh\`:
+Help message for \`run_kraken2pe.sh\`:
     Wrapper for kraken2 taxonomic sequence classification system and associated report and visualization (viz pending)
 
     Primary Output files:
@@ -52,20 +47,10 @@ PARAMS:
  -t  INT	number of threads
  -d  STRING   kraken2 database enum (Viral, MinusB, PlusPFP-16, EuPathDB46) - this will be determined by the cwl tool calling this script
 
- -a  STRING     name of condition1
-
-
-BismarkCov formatted bed:
-    https://www.bioinformatics.babraham.ac.uk/projects/bismark/Bismark_User_Guide.pdf
-    The genome-wide cytosine report (optional) is tab-delimited in the following format (1-based coords):
-    <chromosome> <position> <strand> <count methylated> <count unmethylated> <C-context> <trinucleotide context>
 
 ____________________________________________________________________________________________________
 References:
-	https://rnbeads.org/materials/example_3/differential_methylation.html
-        Makambi, K. (2003) Weighted inverse chi-square method for correlated significance tests. Journal of Applied Statistics, 30(2), 225234
-    https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4216143/
-        Assenov Y, Müller F, Lutsik P, Walter J, Lengauer T, Bock C. Comprehensive analysis of DNA methylation data with RnBeads. Nat Methods. 2014 Nov;11(11):1138-1140. doi: 10.1038/nmeth.3115. Epub 2014 Sep 28. PMID: 25262207; PMCID: PMC4216143.
+    Wood, D.E., Lu, J. & Langmead, B. Improved metagenomic analysis with Kraken 2. Genome Biol 20, 257 (2019). https://doi.org/10.1186/s13059-019-1891-0
 EOF
 }
 
@@ -79,10 +64,6 @@ do
 		h) usage; exit 1 ;;
 		t) THREADS=$OPTARG ;;
         d) DATABASE=$OPTARG ;;
-
-		a) CONDITION1_NAME=$OPTARG ;;
-		b) CONDITION2_NAME=$OPTARG ;;
-
 		?) usage; exit ;;
 	esac
 done
@@ -98,8 +79,6 @@ printf "\tworkdir - $workdir\n\n"
 printf "List of inputs:\n"
 printf "\tTHREADS - $THREADS\n"
 printf "\tGENOME - $GENOME\n"
-printf "\tCONDITION1_NAME - $CONDITION1_NAME\n"
-
 printf "\tOUTDIR - $OUTDIR\n"
 
 
@@ -139,16 +118,6 @@ kraken2 --db $dbpath --threads $THREADS --paired --classified-out classified_rea
 
 # for SE read classification (will use in different script)
 #kraken2 --db /data/k2db/k2_pluspfp_16gb_20221209/ --threads 2 $FASTQ --output kraken.tsv --report kraken.report
-
-
-#	OUTPUTS
-#===============================================================================
-# 
-
-#   format kraken report for table
-
-
-
 
 
 # clean up

--- a/workflows/filter-peaks-by-overlap.cwl
+++ b/workflows/filter-peaks-by-overlap.cwl
@@ -183,7 +183,14 @@ outputs:
         tab: 'Annotated Peak Set Results'
         Title: 'set operated peaks with nearest gene annotation'
 
-  filtering_stdout_log:
+  filtered_file:
+    type: File
+    format: "http://edamontology.org/format_3003"
+    label: "Filtered overlapped peaks in headerless bed format for homer motif analysis"
+    doc: "Regions of interest formatted as headerless BED file with [chrom start end name score strand]"
+    outputSource: formatting_bed_for_homer/headerless_bed
+
+  filtering_stdout_log_file:
     type: File
     format: "http://edamontology.org/format_2330"
     label: "Filtering stdout log"
@@ -229,6 +236,36 @@ steps:
       promoter_bp: promoter_dist
       upstream_bp: upstream_dist
     out: [result_file, log_file]
+
+  formatting_bed_for_homer:
+    run:
+      cwlVersion: v1.0
+      class: CommandLineTool
+      requirements:
+      - class: ScatterFeatureRequirement
+      - class: ShellCommandRequirement
+      inputs:
+        script:
+          type: string?
+          default: |
+            # format for homer [chrom start end name score strand]
+            awk -F'\t' '{printf("%s\t%.0f\t%.0f\t%s\t%s\t%s\n",$6,$3,$4,$2,"NA",$5)}' <(tail -n+2 $0) | sort | uniq > output-for-homer.tsv
+          inputBinding:
+            position: 1
+        input_file:
+          type: File
+          inputBinding:
+            position: 2
+      outputs:
+        headerless_bed:
+          type: File
+          outputBinding:
+            glob: output-for-homer.tsv
+      baseCommand: ["bash", "-c"]
+    in:
+      input_file: island_intersect/result_file
+    out:
+    - headerless_bed
 
 
 $namespaces:

--- a/workflows/homer-motif-analysis-bg.cwl
+++ b/workflows/homer-motif-analysis-bg.cwl
@@ -11,6 +11,14 @@ requirements:
 'sd:upstream':
   genome_indices:
     - "genome-indices.cwl"
+  target_peaklist:
+    - "filter-diffbind-for-heatmap.cwl"
+    - "filter-peaks-by-overlap.cwl"
+    - "genelists-sets.cwl"
+  background_peaklist:
+    - "filter-diffbind-for-heatmap.cwl"
+    - "filter-peaks-by-overlap.cwl"
+    - "genelists-sets.cwl"
 
 
 inputs:
@@ -26,12 +34,16 @@ inputs:
     format: "http://edamontology.org/format_3003"
     label: "Target regions. Headerless BED file with minimum [chrom start end name dummy strand] columns. Optionally, CSV"
     doc: "Target regions. Headerless BED file with minimum [chrom start end unique_id dummy strand] columns. Optionally, CSV"
+    'sd:upstreamSource': "target_peaklist/filtered_file"
+    'sd:localLabel': true
 
   background_regions_file:
     type: File
     format: "http://edamontology.org/format_3003"
     label: "Background regions. Headerless BED file with minimum [chrom start end name dummy strand] columns. Optionally, CSV"
     doc: "Background regions. Headerless BED file with minimum [chrom start end unique_id dummy strand] columns. Optionally, CSV"
+    'sd:upstreamSource': "background_peaklist/filtered_file"
+    'sd:localLabel': true
 
   genome_fasta_file:
     type: File
@@ -127,7 +139,7 @@ outputs:
     label: "Compressed file with Homer motifs"
     doc: "Homer motifs"
 
-  homer_stdout_log:
+  homer_stdout_log_file:
     type: File
     format: "http://edamontology.org/format_2330"
     outputSource: find_motifs/stdout_log

--- a/workflows/homer-motif-analysis-peak.cwl
+++ b/workflows/homer-motif-analysis-peak.cwl
@@ -172,7 +172,7 @@ outputs:
     label: "Compressed file with Homer motifs"
     doc: "Homer motifs"
 
-  homer_stdout_log:
+  homer_stdout_log_file:
     type: File
     format: "http://edamontology.org/format_2330"
     outputSource: find_motifs/stdout_log
@@ -328,9 +328,9 @@ $namespaces:
 $schemas:
 - https://github.com/schemaorg/schemaorg/raw/main/data/releases/11.01/schemaorg-current-http.rdf
 
-label: "Motif Finding with HOMER with target and background regions from peaks"
-s:name: "Motif Finding with HOMER with target and background regions from peaks"
-s:alternateName: "Motif Finding with HOMER with target and background regions from peaks"
+label: "DEPRECATED - Motif Finding with HOMER with target and background regions from peaks"
+s:name: "DEPRECATED - Motif Finding with HOMER with target and background regions from peaks"
+s:alternateName: "DEPRECATED - Motif Finding with HOMER with target and background regions from peaks"
 
 s:downloadUrl: https://raw.githubusercontent.com/datirium/workflows/master/workflows/homer-motif-analysis-peak.cwl
 s:codeRepository: https://github.com/datirium/workflows

--- a/workflows/homer-motif-analysis.cwl
+++ b/workflows/homer-motif-analysis.cwl
@@ -11,7 +11,10 @@ requirements:
 'sd:upstream':
   genome_indices:
     - "genome-indices.cwl"
-
+  peaklist:
+    - "filter-diffbind-for-heatmap.cwl"
+    - "filter-peaks-by-overlap.cwl"
+    - "genelists-sets.cwl"
 
 inputs:
 
@@ -26,6 +29,8 @@ inputs:
     format: "http://edamontology.org/format_3003"
     label: "Regions file. Headerless BED file with minimum [chrom start end] columns. Optionally, CSV"
     doc: "Regions of interest. Formatted as headerless BED file with minimum [chrom start end] columns. Optionally, CSV"
+    'sd:upstreamSource': "peaklist/filtered_file"
+    'sd:localLabel': true
 
   motifs_db:
     type:


### PR DESCRIPTION
1. Added filtered and set operation genelists/peaklists as upstream inputs to (2) homer workflows.
2. Set (1) as DEPRECATED (homer-motif-analysis-peak.cwl, "Motif Finding with HOMER with target and background regions from peaks").
3. Added additional output to peaks overlap (set operation) workflow for homer compatibility.
4. Minor update to kraken script.

homer-motif-analysis-bg.cwl, "Motif Finding with HOMER with custom background regions"
target regions input set genelists as upstream
background regions input set genelists as upstream

homer-motif-analysis-peak.cwl, "Motif Finding with HOMER with target and background regions from peaks"
has 4 total inputs, 2 currently have chip/atac samples as their upstreams and are labeled "Samples to select target regions from" (the other is for background), and another 2 for "diff" target and background regions. Should only the latter 2 be set to use the filtered peak lists as upstream (again, one for targets and one for background)?
set as DEPRECATED

homer-motif-analysis.cwl, "Motif Finding with HOMER with random background regions"
target regions input set genelists as upstream