### PR TITLE
SDAP-1229 diffbind spikein norm workflow etc

### DIFF
--- a/dockerfiles/scidap-diffbind-Dockerfile
+++ b/dockerfiles/scidap-diffbind-Dockerfile
@@ -1,0 +1,67 @@
+#################################################################
+# Software Version: v0.0.16
+# Description:      Differential Binding Analysis
+# Website:          http://www.bioconductor.org/packages/release/bioc/html/DiffBind.html
+# Provides:         diffbind
+# Base Image:       r-base:4.3.1
+# Build Cmd:        docker build --no-cache --rm -t diffbind-dev -f scidap-diffbind-Dockerfile . > ~/Desktop/dockerbuild.log 2>&1
+# Run Cmd:          docker run --rm -ti diffbind-dev /bin/bash
+# Push Cmd1:        docker tag diffbind-dev robertplayer/scidap-diffbind:dev
+#      Cmd2:        docker image push robertplayer/scidap-diffbind:dev
+# Pull Cmd:         docker pull robertplayer/scidap-diffbind:dev
+# Test dev:         docker run --rm -ti robertplayer/scidap-diffbind:dev /bin/bash
+# re-tag for PR:    docker tag diffbind-dev robertplayer/scidap-diffbind:v1.0.0
+# Push for PR:      docker image push robertplayer/scidap-diffbind:v1.0.0
+# Test vx.x.x:      docker run --rm -ti robertplayer/scidap-diffbind:v1.0.0 /bin/bash
+#################################################################
+#
+# v0.0.16
+# - starting from v0.0.16 from Barskilab repo
+# - copying docker scripts into datirium repo
+# - includes all functionality from barskilab diffbind
+# - with new spike-in diffbind script
+#
+#################################################################
+
+
+### Base Image
+FROM r-base:4.3.1
+LABEL maintainer="robert.player@gmail.com"
+ENV DEBIAN_FRONTEND noninteractive
+
+################## BEGIN INSTALLATION ######################
+
+WORKDIR /tmp
+
+COPY ./scripts/run_diffbind.R /usr/local/bin/run_diffbind.R
+COPY ./scripts/run_diffbind_manual.R /usr/local/bin/run_diffbind_manual.R
+COPY ./scripts/run_diffbind-for-spikein.R /usr/local/bin/run_diffbind-for-spikein.R
+
+### Installing dependencies
+RUN apt-get update && \
+    apt-get install -y vim pandoc gcc-10-base libgcc-10-dev cmake python3-dev python3-pip libxml2-dev \
+                       libssl-dev libcurl4-openssl-dev libfontconfig1-dev libharfbuzz-dev libfribidi-dev \
+                       libpng-dev libtiff5-dev libjpeg-dev file && \
+    pip3 install --break-system-packages argparse && \
+### Installing R packages
+    R -e "install.packages('BiocManager')" && \
+    R -e "BiocManager::install(version = '3.17', update=TRUE, ask=FALSE)" && \
+    R -e "BiocManager::install('DiffBind')" && \
+    R -e "BiocManager::install('hopach')" && \
+    R -e "BiocManager::install('cmapR')" && \
+    R -e "BiocManager::install('EnhancedVolcano')" && \
+    R -e "BiocManager::install('Glimma')" && \
+    R -e "BiocManager::install('profileplyr')" && \
+    R -e "BiocManager::install('csaw')" && \
+    R -e 'install.packages("argparse", repo = "https://cloud.r-project.org/")' && \
+    R -e 'install.packages("ggpubr", repo = "https://cloud.r-project.org/")' && \
+    R -e 'install.packages("tidyverse", repo = "https://cloud.r-project.org/")' && \
+### Installing scripts
+    chmod +x /usr/local/bin/run_diffbind.R && \
+    chmod +x /usr/local/bin/run_diffbind_manual.R && \
+    chmod +x /usr/local/bin/run_diffbind-for-spikein.R && \
+### Cleaning
+    apt-get clean && \
+    apt-get purge && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* && \
+    strip /usr/local/bin/*; true

--- a/dockerfiles/scripts/run_diffbind-for-spikein.R
+++ b/dockerfiles/scripts/run_diffbind-for-spikein.R
@@ -1,0 +1,736 @@
+#!/usr/bin/env Rscript
+options(warn=-1)
+options(width=200)
+options(scipen=999)
+
+suppressMessages(library(argparse))
+suppressMessages(library(DiffBind))
+
+
+##########################################################################################
+#
+# v0.0.1
+# - starts from v0.0.14 of 'run_diffbind.cwl'
+# - including inputs for spikein bam files for normalization
+#
+##########################################################################################
+
+
+get_file_type <- function (filename) {
+    ext = tools::file_ext(filename)
+    separator = "\t"
+    if (ext == "csv"){
+        separator = ","
+    }
+    return (separator)
+}
+
+
+load_data_set <- function(diff_dba, peaks, reads, spikein, name, condition, peakformat, replicate, block) {
+    if (is.vector(block)){
+        cat(paste("\nLoading data for condition '", condition, "' as '", name, "', replicate = ", replicate, "\n - ", reads, "\n - ", peaks, "\n", sep=""))
+        diff_dba <- dba.peakset(DBA=diff_dba, sampID=name, peaks=peaks, bamReads=reads, spikein=spikein, replicate=replicate, condition=condition, peak.caller=peakformat)
+    } else {  # load group from dataframe
+        group <- block[name, "group"]
+        cat(paste("\nLoading data for condition '", condition, "' as '", name, "', replicate = ", replicate, ", group = '", group, "'\n - ", reads, "\n - ", peaks, "\n", sep=""))
+        diff_dba <- dba.peakset(DBA=diff_dba, sampID=name, peaks=peaks, bamReads=reads, spikein=spikein, replicate=replicate, condition=condition, tissue=group, peak.caller=peakformat)
+    }
+    return (diff_dba)
+}
+
+
+assert_args <- function(args){
+    if (is.null(args$name1) & is.null(args$name2)){
+        if ( (length(args$read1) != length(args$peak1)) | (length(args$read2) != length(args$peak2)) ){
+            cat("\nNot correct number of inputs provided as -r1, -r2, -p1, -p1")
+            quit(save = "no", status = 1, runLast = FALSE)
+        } else {
+            for (i in 1:length(args$read1)) {
+                args$name1 = append(args$name1, head(unlist(strsplit(basename(args$read1[i]), ".", fixed = TRUE)), 1))
+            }
+            for (i in 1:length(args$read2)) {
+                args$name2 = append(args$name2, head(unlist(strsplit(basename(args$read2[i]), ".", fixed = TRUE)), 1))
+            }
+        }
+    } else {
+        if ( (length(args$read1) != length(args$peak1)) |
+             (length(args$name1) != length(args$peak1)) | 
+             (length(args$read2) != length(args$peak2)) |
+             (length(args$name2) != length(args$peak2)) ){
+            cat("\nNot correct number of inputs provided as -r1, -r2, -p1, -p1, -n1, -n2")
+            quit(save = "no", status = 1, runLast = FALSE)
+        }
+    }
+    if (args$method == "deseq2"){
+        args$method <- DBA_DESEQ2
+    } else if (args$method == "edger") {
+        args$method <- DBA_EDGER
+    } else if (args$method == "all") {
+        args$method <- DBA_ALL_METHODS_BLOCK
+    }
+
+    if (args$cparam == "fdr"){
+        args$cparam <- FALSE
+    } else if (args$cparam == "pvalue") {
+        args$cparam <- TRUE
+    }
+
+    if (args$usecommon){
+        args$minoverlap = 1
+    }
+
+    if (!is.null(args$blockfile)){
+        block_metadata <- read.table(
+            args$blockfile,
+            sep=get_file_type(args$blockfile),
+            row.names=1,
+            col.names=c("name", "group"),
+            header=FALSE,
+            stringsAsFactors=FALSE
+        )
+        if (all(is.element(c(args$name1, args$name2), rownames(block_metadata)))){
+            args$block <- block_metadata  # dataframe
+        } else {
+            cat("\nMissing values in block metadata file. Using non-blocked analysis\n")
+            args$block = rep(FALSE,length(args$read1)+length(args$read2))  # boolean vector
+        }
+    } else if (!is.null(args$block)){
+        blocked_attributes = as.logical(args$block)
+        if (any(is.na(blocked_attributes)) | length(blocked_attributes) != length(args$read1)+length(args$read2) ){
+            args$block = is.element(c(args$name1, args$name2), args$block)  # boolean vector
+        } else {
+            args$block = blocked_attributes  # boolean vector
+        }
+    } else {
+        args$block = rep(FALSE,length(args$read1)+length(args$read2))  # boolean vector
+    }
+
+    return (args)
+}
+
+
+export_raw_counts_correlation_heatmap <- function(dba_data, rootname, padding, color_scheme, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotHeatmap(dba_data, margin=padding, score=DBA_SCORE_READS, colScheme=color_scheme)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotHeatmap(dba_data, margin=padding, score=DBA_SCORE_READS, colScheme=color_scheme)
+            dev.off()
+
+            cat(paste("\nExport raw counts correlation heatmap to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export raw counts correlation heatmap to ", rootname, ".(png/pdf)",  sep=""))
+        }
+    )
+}
+
+
+export_peak_overlap_correlation_heatmap <- function(dba_data, rootname, padding, color_scheme, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotHeatmap(dba_data, margin=padding, colScheme=color_scheme)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotHeatmap(dba_data, margin=padding, colScheme=color_scheme)
+            dev.off()
+
+            cat(paste("\nExport peak overlap correlation heatmap to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export peak overlap correlation heatmap to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_peak_overlap_rate_plot <- function(peak_overlap_rate, rootname, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            plot(peak_overlap_rate, type='b', ylab='# peaks', xlab='Overlap at least this many peaksets', pch=19, cex=2)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            plot(peak_overlap_rate, type='b', ylab='# peaks', xlab='Overlap at least this many peaksets', pch=19, cex=2)
+            dev.off()
+
+            cat(paste("\nExport peak overlap rate plot to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export peak overlap rate plot to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_normalized_counts_correlation_heatmap <- function(dba_data, rootname, method, padding, color_scheme, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotHeatmap(dba_data, contrast=1, colScheme=color_scheme, th=th, bUsePval=use_pval, method=method, margin=padding)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotHeatmap(dba_data, contrast=1, colScheme=color_scheme, th=th, bUsePval=use_pval, method=method, margin=padding)
+            dev.off()
+
+            cat(paste("\nExport normalized counts correlation heatmap to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export normalized counts correlation heatmap to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_binding_heatmap <- function(dba_data, rootname, method, padding, color_scheme, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+            
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotHeatmap(dba_data, contrast=1, colScheme=color_scheme, correlations=FALSE, th=th, bUsePval=use_pval, method=method, margin=padding, scale="row")
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotHeatmap(dba_data, contrast=1, colScheme=color_scheme, correlations=FALSE, th=th, bUsePval=use_pval, method=method, margin=padding, scale="row")
+            dev.off()
+
+            cat(paste("\nExport binding heatmap to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export binding heatmap to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_pca_plot <- function(dba_data, rootname, method, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotPCA(dba_data, attributes=DBA_CONDITION, contrast=1, th=th, bUsePval=use_pval, label=DBA_ID, method=method)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotPCA(dba_data, attributes=DBA_CONDITION, contrast=1, th=th, bUsePval=use_pval, label=DBA_ID, method=method)
+            dev.off()
+
+            cat(paste("\nExport PCA plot to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export PCA plot to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_ma_plot <- function(dba_data, rootname, method, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+            
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotMA(dba_data, contrast=1, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotMA(dba_data, contrast=1, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            cat(paste("\nExport MA plot to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export MA plot to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_volcano_plot <- function(dba_data, rootname, method, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotVolcano(dba_data, contrast=1, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotVolcano(dba_data, contrast=1, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            cat(paste("\nExport volcano plot to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export volcano plot to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_box_plot <- function(dba_data, rootname, method, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotBox(dba_data, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotBox(dba_data, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            cat(paste("\nExport box plot to", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export box plot to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_consensus_peak_venn_diagram <- function(dba_data, rootname, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotVenn(dba_data, mask=dba_data$masks$Consensus)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotVenn(dba_data, mask=dba_data$masks$Consensus)
+            dev.off()
+
+            cat(paste("\nExport consensus peak venn diagram to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export consensus peak venn diagram to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_results <- function(dba_data, filename, method, th=1, use_pval=FALSE){
+    tryCatch(
+        expr = {
+            diff_dba.DB <- dba.report(dba_data, contrast=1, DataType=DBA_DATA_FRAME, method=method, bCalled=TRUE, bCounts=TRUE, th=th, bUsePval=use_pval)
+            if (!is.null(diff_dba.DB)){
+                write.table(diff_dba.DB, file=filename, sep="\t", row.names=FALSE, col.names=TRUE, quote=FALSE)
+                cat(paste("\nExport differential binding analysis results as TSV to", filename, sep=" "))
+            } else {
+                cat(paste("\nSkip exporting differential binding analysis results as TSV to", filename, "[no data]", sep=" "))
+            }
+        },
+        error = function(e){
+            cat(paste("\nFailed to export differential binding analysis results as TSV to", filename, sep=" "))
+        }
+    )
+}
+
+
+get_args <- function(){
+    parser <- ArgumentParser(description='Differential binding analysis of ChIP-Seq experiments using affinity (read count) data')
+    parser$add_argument("-r1", "--read1",        help='Read files for condition 1. Minimim 2 files in BAM format', type="character", required="True",  nargs='+')
+    parser$add_argument("-r2", "--read2",        help='Read files for condition 2. Minimim 2 files in BAM format', type="character", required="True",  nargs='+')
+    parser$add_argument("-s1", "--spike1",       help='Spike-in read files for condition 1. Minimim 2 files in BAM format', type="character", required="True",  nargs='+')
+    parser$add_argument("-s2", "--spike2",       help='Spike-in read files for condition 2. Minimim 2 files in BAM format', type="character", required="True",  nargs='+')
+    parser$add_argument("-p1", "--peak1",        help='Peak files for condition 1. Minimim 2 files in format set with -pf', type="character", required="True",  nargs='+')
+    parser$add_argument("-p2", "--peak2",        help='Peak files for condition 2. Minimim 2 files in format set with -pf', type="character", required="True",  nargs='+')
+
+    parser$add_argument("-n1", "--name1",        help='Sample names for condition 1. Default: basenames of -r1 without extensions', type="character", nargs='*')
+    parser$add_argument("-n2", "--name2",        help='Sample names for condition 2. Default: basenames of -r2 without extensions', type="character", nargs='*')
+
+    parser$add_argument("-bl", "--block",        help='Blocking attribute for multi-factor analysis. Minimum 2. Either names from --name1 or/and --name2 or array of bool based on [read1]+[read2]. Default: not applied', type="character", nargs='*')
+    parser$add_argument("-bf", "--blockfile",    help='Blocking attribute metadata file for multi-factor analysis. Headerless TSV/CSV file. First column - names from --name1 and --name2, second column - group name. --block is ignored', type="character")
+
+    parser$add_argument("-pf", "--peakformat",   help='Peak files format. One of [raw, bed, narrow, macs, bayes, tpic, sicer, fp4, swembl, csv, report]. Default: macs', type="character", choices=c("raw","bed","narrow","macs","bayes","tpic","sicer","fp4","swembl","csv","report"), default="macs")
+
+    parser$add_argument("-c1", "--condition1",   help='Condition 1 name, single word with letters and numbers only. Default: condition_1', type="character", default="condition_1")
+    parser$add_argument("-c2", "--condition2",   help='Condition 2 name, single word with letters and numbers only. Default: condition_2', type="character", default="condition_2")
+    parser$add_argument("-me", "--method",       help='Method by which to analyze differential binding affinity. Default: all', type="character", choices=c("edger","deseq2","all"), default="all")
+    parser$add_argument("-mo", "--minoverlap",   help='Min peakset overlap. Only include peaks in at least this many peaksets when generating consensus peakset. Default: 2', type="integer", default=2)
+    parser$add_argument("-uc", "--usecommon",    help='Derive consensus peaks only from the common peaks within each condition. Min peakset overlap and min read counts are ignored. Default: false', action='store_true')
+    parser$add_argument(
+        "--summits",
+        help=paste(
+            "Width in bp to extend peaks around their summits in both directions",
+            "and replace the original ones. Set it to 100 bp for ATAC-Seq and 200",
+            "bp for ChIP-Seq datasets. To skip peaks extension and replacement, set",
+            "it to negative value. Default: 200 bp (results in 401 bp wide peaks)"
+        ),
+        type="integer", default=200
+    )
+    parser$add_argument("-cu", "--cutoff",       help='Cutoff for reported results. Applied to the parameter set with -cp. Default: 0.05', type="double",    default=0.05)
+    parser$add_argument("-cp", "--cparam",       help='Parameter to which cutoff should be applied (fdr or pvalue). Default: fdr',         type="character", choices=c("pvalue","fdr"), default="fdr")
+
+    parser$add_argument("-co", "--color",        help='Color scheme. Default: Greens', type="character", choices=c("Reds", "Greens", "Blues", "Greys", "YlOrRd", "Oranges"), default="Greens")
+    parser$add_argument("-th", "--threads",      help='Threads to use',                                     type="integer",   default=1)
+    parser$add_argument("-pa", "--padding",      help='Padding for generated heatmaps. Default: 20',        type="integer",   default=20)
+    parser$add_argument("-o",  "--output",       help='Output prefix. Default: diffbind',                   type="character", default="./diffbind")
+    args <- assert_args(parser$parse_args(commandArgs(trailingOnly = TRUE)))
+    return (args)
+}
+
+
+args <- get_args()
+
+
+diff_dba <- NULL
+for (i in 1:length(args$read1)){
+    diff_dba <- load_data_set(diff_dba, args$peak1[i], args$read1[i], args$spike1[i], args$name1[i], args$condition1, args$peakformat, i, args$block)
+}
+for (i in 1:length(args$read2)){
+    diff_dba <- load_data_set(diff_dba, args$peak2[i], args$read2[i], args$spike2[i], args$name2[i], args$condition2, args$peakformat, i, args$block)
+}
+
+
+diff_dba$config$cores <- args$threads
+
+
+cat("\nLoaded data\n - chrM removed\n - intersected peaks merged\n\n")
+print(diff_dba)
+
+
+mask_cond_1 <- dba.mask(diff_dba, attribute=DBA_CONDITION, value=args$condition1)
+mask_cond_2 <- dba.mask(diff_dba, attribute=DBA_CONDITION, value=args$condition2)
+mask_cond_both <- as.logical(mask_cond_1 + mask_cond_2)
+
+if (args$usecommon){
+    cat("\nDeriving consensus peaks only from the common peaks within each condition. Min peakset overlap is ignored.\n")
+    diff_dba_consensus <- dba.peakset(diff_dba, consensus=DBA_CONDITION, minOverlap=0.99)  # use 0.99 to include all intersected peaks within condition
+    diff_dba_consensus <- dba(diff_dba_consensus, mask=diff_dba_consensus$masks$Consensus, minOverlap=args$minoverlap)
+    cat("\nDerived consensus data\n - intersected peaks merged\n\n")
+    print(diff_dba_consensus)
+    consensus_peaks <- dba.peakset(diff_dba_consensus, bRetrieve=TRUE, minOverlap=args$minoverlap)
+    cat("\nConsensus peaks\n\n")
+    print(consensus_peaks)
+    export_consensus_peak_venn_diagram(diff_dba_consensus, paste(args$output, "_consensus_peak_venn_diagram", sep=""))
+}
+
+
+# Get peak overlap rates, export plots
+cat("\n")
+cat(paste("\nPeak overlap rate for", args$condition1, "\n", sep=" "))
+peak_overlap_rate_cond_1 = dba.overlap(diff_dba, mask=mask_cond_1, mode=DBA_OLAP_RATE)
+print(peak_overlap_rate_cond_1)
+
+cat(paste("\nPeak overlap rate for", args$condition2, "\n", sep=" "))
+peak_overlap_rate_cond_2 = dba.overlap(diff_dba, mask=mask_cond_2, mode=DBA_OLAP_RATE)
+print(peak_overlap_rate_cond_2)
+
+export_peak_overlap_rate_plot(peak_overlap_rate_cond_1, paste(args$output, "_condition_1_peak_overlap_rate", sep=""))
+export_peak_overlap_rate_plot(peak_overlap_rate_cond_2, paste(args$output, "_condition_2_peak_overlap_rate", sep=""))
+
+if (!args$usecommon){
+    peak_overlap_rate_all = dba.overlap(diff_dba, mode=DBA_OLAP_RATE)
+    cat("\n\nPeak overlap rate for all peaksets\n")
+    print(peak_overlap_rate_all)
+    export_peak_overlap_rate_plot(peak_overlap_rate_all, paste(args$output, "_all_peak_overlap_rate", sep=""))
+}
+
+
+# Export peak overlap correlation heatmap
+export_peak_overlap_correlation_heatmap(diff_dba, paste(args$output, "_peak_overlap_correlation_heatmap", sep=""), args$padding, args$color)
+
+
+# Count reads in binding site intervals
+cat(paste("\n\nCount reads using", diff_dba$config$cores, "threads. Min peakset overlap is set to", args$minoverlap, "\n", sep=" "))
+
+if (args$usecommon){
+    diff_dba <- dba.count(
+        diff_dba,
+        peaks=consensus_peaks,
+        summits=ifelse(args$summits >= 0, args$summits, FALSE),
+        minOverlap=args$minoverlap
+    )
+} else {
+    diff_dba <- dba.count(
+        diff_dba,
+        summits=ifelse(args$summits >= 0, args$summits, FALSE),
+        minOverlap=args$minoverlap
+    )
+}
+
+cat("\nCounted data\n\n")
+print(diff_dba)
+
+
+# Export raw counts correlation heatmap
+export_raw_counts_correlation_heatmap(diff_dba, paste(args$output, "_raw_counts_correlation_heatmap", sep=""), args$padding, args$color)
+
+
+# Export consensus peak venn diagram
+if (!args$usecommon){
+    export_consensus_peak_venn_diagram(diff_dba, paste(args$output, "_consensus_peak_venn_diagram", sep=""))
+}
+
+
+# Establish contrast
+metadata = dba.show(diff_dba)
+diff_dba$contrasts <- NULL
+cat(paste("\n\nEstablish contrast [", paste(metadata[metadata["Condition"]==args$condition1, "ID"], collapse=", "), "] vs [", paste(metadata[metadata["Condition"]==args$condition2, "ID"], collapse=", "), "]", "\n\n", sep=""))
+if (is.vector(args$block)){
+    cat(paste("Blocked attributes [", paste(metadata[args$block, "ID"], collapse=", "), "]", "\n\n", sep=""))
+    diff_dba <- dba.contrast(diff_dba, group1=mask_cond_1, group2=mask_cond_2, name1=args$condition1, name2=args$condition2, block=args$block)
+} else {
+    cat("Blocked attributes\n")
+    print(args$block)
+    cat("\n")
+    diff_dba <- dba.contrast(diff_dba, group1=mask_cond_1, group2=mask_cond_2, name1=args$condition1, name2=args$condition2, block=DBA_TISSUE)
+}
+
+#diff_dba <- dba.analyze(diff_dba, method=args$method)
+spikes <- dba.normalize(diff_dba, normalize="RLE", background=TRUE)
+diff_dba <- dba.analyze(spikes, method=args$method)
+
+cat("\nAnalyzed data\n\n")
+print(diff_dba)
+
+
+# Export all normalized counts correlation heatmaps
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_all_normalized_counts_correlation_heatmap_deseq", sep=""),
+                                             DBA_DESEQ2,
+                                             args$padding,
+                                             args$color)
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_all_normalized_counts_correlation_heatmap_deseq_block", sep=""),
+                                             DBA_DESEQ2_BLOCK,
+                                             args$padding,
+                                             args$color)
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_all_normalized_counts_correlation_heatmap_edger", sep=""),
+                                             DBA_EDGER,
+                                             args$padding,
+                                             args$color)
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_all_normalized_counts_correlation_heatmap_edger_block", sep=""),
+                                             DBA_EDGER_BLOCK,
+                                             args$padding,
+                                             args$color)
+
+
+# Export filtered normalized counts correlation heatmaps
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_filtered_normalized_counts_correlation_heatmap_deseq", sep=""),
+                                             DBA_DESEQ2,
+                                             args$padding,
+                                             args$color,
+                                             args$cutoff,
+                                             args$cparam)
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_filtered_normalized_counts_correlation_heatmap_deseq_block", sep=""),
+                                             DBA_DESEQ2_BLOCK,
+                                             args$padding,
+                                             args$color,
+                                             args$cutoff,
+                                             args$cparam)                                             
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_filtered_normalized_counts_correlation_heatmap_edger", sep=""),
+                                             DBA_EDGER,
+                                             args$padding,
+                                             args$color,
+                                             args$cutoff,
+                                             args$cparam)
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_filtered_normalized_counts_correlation_heatmap_edger_block", sep=""),
+                                             DBA_EDGER_BLOCK,
+                                             args$padding,
+                                             args$color,
+                                             args$cutoff,
+                                             args$cparam)
+
+
+# Export filtered binding heatmaps
+export_binding_heatmap(diff_dba,
+                       paste(args$output, "_filtered_binding_heatmap_deseq", sep=""),
+                       DBA_DESEQ2,
+                       args$padding,
+                       args$color,
+                       args$cutoff,
+                       args$cparam)
+export_binding_heatmap(diff_dba,
+                       paste(args$output, "_filtered_binding_heatmap_deseq_block", sep=""),
+                       DBA_DESEQ2_BLOCK,
+                       args$padding,
+                       args$color,
+                       args$cutoff,
+                       args$cparam)
+export_binding_heatmap(diff_dba,
+                       paste(args$output, "_filtered_binding_heatmap_edger", sep=""),
+                       DBA_EDGER,
+                       args$padding,
+                       args$color,
+                       args$cutoff,
+                       args$cparam)
+export_binding_heatmap(diff_dba,
+                       paste(args$output, "_filtered_binding_heatmap_edger_block", sep=""),
+                       DBA_EDGER_BLOCK,
+                       args$padding,
+                       args$color,
+                       args$cutoff,
+                       args$cparam)
+
+
+# Export not filtered PCA plots
+export_pca_plot(diff_dba,
+                paste(args$output, "_all_pca_plot_deseq", sep=""),
+                DBA_DESEQ2)
+export_pca_plot(diff_dba,
+                paste(args$output, "_all_pca_plot_deseq_block", sep=""),
+                DBA_DESEQ2_BLOCK)
+export_pca_plot(diff_dba,
+                paste(args$output, "_all_pca_plot_edger", sep=""),
+                DBA_EDGER)
+export_pca_plot(diff_dba,
+                paste(args$output, "_all_pca_plot_edger_block", sep=""),
+                DBA_EDGER_BLOCK)
+
+
+# Export filtered PCA plots
+export_pca_plot(diff_dba,
+                paste(args$output, "_filtered_pca_plot_deseq", sep=""),
+                DBA_DESEQ2,
+                args$cutoff,
+                args$cparam)
+export_pca_plot(diff_dba,
+                paste(args$output, "_filtered_pca_plot_deseq_block", sep=""),
+                DBA_DESEQ2_BLOCK,
+                args$cutoff,
+                args$cparam)
+export_pca_plot(diff_dba,
+                paste(args$output, "_filtered_pca_plot_edger", sep=""),
+                DBA_EDGER,
+                args$cutoff,
+                args$cparam)
+export_pca_plot(diff_dba,
+                paste(args$output, "_filtered_pca_plot_edger_block", sep=""),
+                DBA_EDGER_BLOCK,
+                args$cutoff,
+                args$cparam)
+
+
+# Export filtered MA plot
+export_ma_plot(diff_dba,
+               paste(args$output, "_filtered_ma_plot_deseq", sep=""),
+               DBA_DESEQ2,
+               args$cutoff,
+               args$cparam)
+export_ma_plot(diff_dba,
+               paste(args$output, "_filtered_ma_plot_deseq_block", sep=""),
+               DBA_DESEQ2_BLOCK,
+               args$cutoff,
+               args$cparam)
+export_ma_plot(diff_dba,
+               paste(args$output, "_filtered_ma_plot_edger", sep=""),
+               DBA_EDGER,
+               args$cutoff,
+               args$cparam)
+export_ma_plot(diff_dba,
+               paste(args$output, "_filtered_ma_plot_edger_block", sep=""),
+               DBA_EDGER_BLOCK,
+               args$cutoff,
+               args$cparam)
+
+
+# Export filtered volcano plots
+export_volcano_plot(diff_dba,
+                    paste(args$output, "_filtered_volcano_plot_deseq", sep=""),
+                    DBA_DESEQ2,
+                    args$cutoff,
+                    args$cparam)
+export_volcano_plot(diff_dba,
+                    paste(args$output, "_filtered_volcano_plot_deseq_block", sep=""),
+                    DBA_DESEQ2_BLOCK,
+                    args$cutoff,
+                    args$cparam)
+export_volcano_plot(diff_dba,
+                    paste(args$output, "_filtered_volcano_plot_edger", sep=""),
+                    DBA_EDGER,
+                    args$cutoff,
+                    args$cparam)
+export_volcano_plot(diff_dba,
+                    paste(args$output, "_filtered_volcano_plot_edger_block", sep=""),
+                    DBA_EDGER_BLOCK,
+                    args$cutoff,
+                    args$cparam)
+
+
+# Export filtered box plots
+export_box_plot(diff_dba,
+                paste(args$output, "_filtered_box_plot_deseq", sep=""),
+                DBA_DESEQ2,
+                args$cutoff,
+                args$cparam)
+export_box_plot(diff_dba,
+                paste(args$output, "_filtered_box_plot_deseq_block", sep=""),
+                DBA_DESEQ2_BLOCK,
+                args$cutoff,
+                args$cparam)
+export_box_plot(diff_dba,
+                paste(args$output, "_filtered_box_plot_edger", sep=""),
+                DBA_EDGER,
+                args$cutoff,
+                args$cparam)
+export_box_plot(diff_dba,
+                paste(args$output, "_filtered_box_plot_edger_block", sep=""),
+                DBA_EDGER_BLOCK,
+                args$cutoff,
+                args$cparam)
+
+
+# Export filtered results
+export_results(diff_dba,
+               paste(args$output, "_filtered_report_deseq.tsv", sep=""),
+               DBA_DESEQ2,
+               args$cutoff,
+               args$cparam)
+export_results(diff_dba,
+               paste(args$output, "_filtered_report_deseq_block.tsv", sep=""),
+               DBA_DESEQ2_BLOCK,
+               args$cutoff,
+               args$cparam)
+export_results(diff_dba,
+               paste(args$output, "_filtered_report_edger.tsv", sep=""),
+               DBA_EDGER,
+               args$cutoff,
+               args$cparam)
+export_results(diff_dba,
+               paste(args$output, "_filtered_report_edger_block.tsv", sep=""),
+               DBA_EDGER_BLOCK,
+               args$cutoff,
+               args$cparam)
+
+
+# Export not filtered results
+export_results(diff_dba,
+               paste(args$output, "_all_report_deseq.tsv", sep=""),
+               DBA_DESEQ2)
+export_results(diff_dba,
+               paste(args$output, "_all_report_deseq_block.tsv", sep=""),
+               DBA_DESEQ2_BLOCK)
+export_results(diff_dba,
+               paste(args$output, "_all_report_edger.tsv", sep=""),
+               DBA_EDGER)
+export_results(diff_dba,
+               paste(args$output, "_all_report_edger_block.tsv", sep=""),
+               DBA_EDGER_BLOCK)

--- a/dockerfiles/scripts/run_diffbind.R
+++ b/dockerfiles/scripts/run_diffbind.R
@@ -1,0 +1,784 @@
+#!/usr/bin/env Rscript
+options(warn=-1)
+options(width=200)
+options(scipen=999)
+
+suppressMessages(library(argparse))
+suppressMessages(library(DiffBind))
+
+
+##########################################################################################
+#
+# v0.0.14
+# - add --color parameter
+#
+# v0.0.13
+# - add --blockfile to set multiple groups for multi-factor analysis
+#
+# v0.0.12
+# - export all graphics to pdf too
+# - allow to filter out intervals with low raw read counts
+#
+# v0.0.11
+# - add occupancy based consensus peak selection
+#
+# v0.0.10
+# - suppress scientific notation when exporting to TSV
+#
+# v0.0.9
+# - export not filtered TSV results
+#
+# v0.0.8
+# - supports blocking analyses for DESeq2 and EdgeR
+#
+# v0.0.7
+# - add tryCatch to all optional outputs
+#
+# v0.0.6
+# - filtering by P-value or FDR
+#
+# v0.0.5
+# - add P-value cutoff for reported results
+#
+# v0.0.4
+# - increased default padding for generated heatmaps
+#
+# v0.0.3
+# - allows to control threads number
+#
+# v0.0.2
+# - exports
+#   * peak overlap correlation heatmap
+#   * counts correlation heatmap
+#   * correlation heatmap based on all normalized data
+#   * correlation heatmap based on DB sites only
+#   * PCA plot using affinity data for only differentially bound sites
+#   * MA plot
+#   * volcano plot
+#   * box plots of read distributions for significantly differentially bound (DB) sites
+# - allows to choose from deseq2 or edger
+#
+# v0.0.1
+# - use DiffBind with default parameters
+# - use only condition option in comparison
+# - export results as TSV
+#
+##########################################################################################
+
+
+get_file_type <- function (filename) {
+    ext = tools::file_ext(filename)
+    separator = "\t"
+    if (ext == "csv"){
+        separator = ","
+    }
+    return (separator)
+}
+
+
+load_data_set <- function(diff_dba, peaks, reads, name, condition, peakformat, replicate, block) {
+    if (is.vector(block)){
+        cat(paste("\nLoading data for condition '", condition, "' as '", name, "', replicate = ", replicate, "\n - ", reads, "\n - ", peaks, "\n", sep=""))
+        diff_dba <- dba.peakset(DBA=diff_dba, sampID=name, peaks=peaks, bamReads=reads, replicate=replicate, condition=condition, peak.caller=peakformat)
+    } else {  # load group from dataframe
+        group <- block[name, "group"]
+        cat(paste("\nLoading data for condition '", condition, "' as '", name, "', replicate = ", replicate, ", group = '", group, "'\n - ", reads, "\n - ", peaks, "\n", sep=""))
+        diff_dba <- dba.peakset(DBA=diff_dba, sampID=name, peaks=peaks, bamReads=reads, replicate=replicate, condition=condition, tissue=group, peak.caller=peakformat)
+    }
+    return (diff_dba)
+}
+
+
+assert_args <- function(args){
+    if (is.null(args$name1) & is.null(args$name2)){
+        if ( (length(args$read1) != length(args$peak1)) | (length(args$read2) != length(args$peak2)) ){
+            cat("\nNot correct number of inputs provided as -r1, -r2, -p1, -p1")
+            quit(save = "no", status = 1, runLast = FALSE)
+        } else {
+            for (i in 1:length(args$read1)) {
+                args$name1 = append(args$name1, head(unlist(strsplit(basename(args$read1[i]), ".", fixed = TRUE)), 1))
+            }
+            for (i in 1:length(args$read2)) {
+                args$name2 = append(args$name2, head(unlist(strsplit(basename(args$read2[i]), ".", fixed = TRUE)), 1))
+            }
+        }
+    } else {
+        if ( (length(args$read1) != length(args$peak1)) |
+             (length(args$name1) != length(args$peak1)) | 
+             (length(args$read2) != length(args$peak2)) |
+             (length(args$name2) != length(args$peak2)) ){
+            cat("\nNot correct number of inputs provided as -r1, -r2, -p1, -p1, -n1, -n2")
+            quit(save = "no", status = 1, runLast = FALSE)
+        }
+    }
+    if (args$method == "deseq2"){
+        args$method <- DBA_DESEQ2
+    } else if (args$method == "edger") {
+        args$method <- DBA_EDGER
+    } else if (args$method == "all") {
+        args$method <- DBA_ALL_METHODS_BLOCK
+    }
+
+    if (args$cparam == "fdr"){
+        args$cparam <- FALSE
+    } else if (args$cparam == "pvalue") {
+        args$cparam <- TRUE
+    }
+
+    if (args$usecommon){
+        args$minoverlap = 1
+    }
+
+    if (!is.null(args$blockfile)){
+        block_metadata <- read.table(
+            args$blockfile,
+            sep=get_file_type(args$blockfile),
+            row.names=1,
+            col.names=c("name", "group"),
+            header=FALSE,
+            stringsAsFactors=FALSE
+        )
+        if (all(is.element(c(args$name1, args$name2), rownames(block_metadata)))){
+            args$block <- block_metadata  # dataframe
+        } else {
+            cat("\nMissing values in block metadata file. Using non-blocked analysis\n")
+            args$block = rep(FALSE,length(args$read1)+length(args$read2))  # boolean vector
+        }
+    } else if (!is.null(args$block)){
+        blocked_attributes = as.logical(args$block)
+        if (any(is.na(blocked_attributes)) | length(blocked_attributes) != length(args$read1)+length(args$read2) ){
+            args$block = is.element(c(args$name1, args$name2), args$block)  # boolean vector
+        } else {
+            args$block = blocked_attributes  # boolean vector
+        }
+    } else {
+        args$block = rep(FALSE,length(args$read1)+length(args$read2))  # boolean vector
+    }
+
+    return (args)
+}
+
+
+export_raw_counts_correlation_heatmap <- function(dba_data, rootname, padding, color_scheme, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotHeatmap(dba_data, margin=padding, score=DBA_SCORE_READS, colScheme=color_scheme)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotHeatmap(dba_data, margin=padding, score=DBA_SCORE_READS, colScheme=color_scheme)
+            dev.off()
+
+            cat(paste("\nExport raw counts correlation heatmap to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export raw counts correlation heatmap to ", rootname, ".(png/pdf)",  sep=""))
+        }
+    )
+}
+
+
+export_peak_overlap_correlation_heatmap <- function(dba_data, rootname, padding, color_scheme, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotHeatmap(dba_data, margin=padding, colScheme=color_scheme)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotHeatmap(dba_data, margin=padding, colScheme=color_scheme)
+            dev.off()
+
+            cat(paste("\nExport peak overlap correlation heatmap to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export peak overlap correlation heatmap to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_peak_overlap_rate_plot <- function(peak_overlap_rate, rootname, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            plot(peak_overlap_rate, type='b', ylab='# peaks', xlab='Overlap at least this many peaksets', pch=19, cex=2)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            plot(peak_overlap_rate, type='b', ylab='# peaks', xlab='Overlap at least this many peaksets', pch=19, cex=2)
+            dev.off()
+
+            cat(paste("\nExport peak overlap rate plot to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export peak overlap rate plot to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_normalized_counts_correlation_heatmap <- function(dba_data, rootname, method, padding, color_scheme, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotHeatmap(dba_data, contrast=1, colScheme=color_scheme, th=th, bUsePval=use_pval, method=method, margin=padding)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotHeatmap(dba_data, contrast=1, colScheme=color_scheme, th=th, bUsePval=use_pval, method=method, margin=padding)
+            dev.off()
+
+            cat(paste("\nExport normalized counts correlation heatmap to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export normalized counts correlation heatmap to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_binding_heatmap <- function(dba_data, rootname, method, padding, color_scheme, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+            
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotHeatmap(dba_data, contrast=1, colScheme=color_scheme, correlations=FALSE, th=th, bUsePval=use_pval, method=method, margin=padding, scale="row")
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotHeatmap(dba_data, contrast=1, colScheme=color_scheme, correlations=FALSE, th=th, bUsePval=use_pval, method=method, margin=padding, scale="row")
+            dev.off()
+
+            cat(paste("\nExport binding heatmap to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export binding heatmap to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_pca_plot <- function(dba_data, rootname, method, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotPCA(dba_data, attributes=DBA_CONDITION, contrast=1, th=th, bUsePval=use_pval, label=DBA_ID, method=method)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotPCA(dba_data, attributes=DBA_CONDITION, contrast=1, th=th, bUsePval=use_pval, label=DBA_ID, method=method)
+            dev.off()
+
+            cat(paste("\nExport PCA plot to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export PCA plot to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_ma_plot <- function(dba_data, rootname, method, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+            
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotMA(dba_data, contrast=1, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotMA(dba_data, contrast=1, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            cat(paste("\nExport MA plot to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export MA plot to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_volcano_plot <- function(dba_data, rootname, method, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotVolcano(dba_data, contrast=1, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotVolcano(dba_data, contrast=1, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            cat(paste("\nExport volcano plot to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export volcano plot to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_box_plot <- function(dba_data, rootname, method, th=1, use_pval=FALSE, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotBox(dba_data, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotBox(dba_data, method=method, th=th, bUsePval=use_pval)
+            dev.off()
+
+            cat(paste("\nExport box plot to", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export box plot to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_consensus_peak_venn_diagram <- function(dba_data, rootname, width=800, height=800, res=72){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=res)
+            dba.plotVenn(dba_data, mask=dba_data$masks$Consensus)
+            dev.off()
+
+            pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/res), height=round(height/res))
+            dba.plotVenn(dba_data, mask=dba_data$masks$Consensus)
+            dev.off()
+
+            cat(paste("\nExport consensus peak venn diagram to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            dev.off()
+            cat(paste("\nFailed to export consensus peak venn diagram to ", rootname, ".(png/pdf)", sep=""))
+        }
+    )
+}
+
+
+export_results <- function(dba_data, filename, method, th=1, use_pval=FALSE){
+    tryCatch(
+        expr = {
+            diff_dba.DB <- dba.report(dba_data, contrast=1, DataType=DBA_DATA_FRAME, method=method, bCalled=TRUE, bCounts=TRUE, th=th, bUsePval=use_pval)
+            if (!is.null(diff_dba.DB)){
+                write.table(diff_dba.DB, file=filename, sep="\t", row.names=FALSE, col.names=TRUE, quote=FALSE)
+                cat(paste("\nExport differential binding analysis results as TSV to", filename, sep=" "))
+            } else {
+                cat(paste("\nSkip exporting differential binding analysis results as TSV to", filename, "[no data]", sep=" "))
+            }
+        },
+        error = function(e){
+            cat(paste("\nFailed to export differential binding analysis results as TSV to", filename, sep=" "))
+        }
+    )
+}
+
+
+get_args <- function(){
+    parser <- ArgumentParser(description='Differential binding analysis of ChIP-Seq experiments using affinity (read count) data')
+    parser$add_argument("-r1", "--read1",        help='Read files for condition 1. Minimim 2 files in BAM format', type="character", required="True",  nargs='+')
+    parser$add_argument("-r2", "--read2",        help='Read files for condition 2. Minimim 2 files in BAM format', type="character", required="True",  nargs='+')
+    parser$add_argument("-p1", "--peak1",        help='Peak files for condition 1. Minimim 2 files in format set with -pf', type="character", required="True",  nargs='+')
+    parser$add_argument("-p2", "--peak2",        help='Peak files for condition 2. Minimim 2 files in format set with -pf', type="character", required="True",  nargs='+')
+
+    parser$add_argument("-n1", "--name1",        help='Sample names for condition 1. Default: basenames of -r1 without extensions', type="character", nargs='*')
+    parser$add_argument("-n2", "--name2",        help='Sample names for condition 2. Default: basenames of -r2 without extensions', type="character", nargs='*')
+
+    parser$add_argument("-bl", "--block",        help='Blocking attribute for multi-factor analysis. Minimum 2. Either names from --name1 or/and --name2 or array of bool based on [read1]+[read2]. Default: not applied', type="character", nargs='*')
+    parser$add_argument("-bf", "--blockfile",    help='Blocking attribute metadata file for multi-factor analysis. Headerless TSV/CSV file. First column - names from --name1 and --name2, second column - group name. --block is ignored', type="character")
+
+    parser$add_argument("-pf", "--peakformat",   help='Peak files format. One of [raw, bed, narrow, macs, bayes, tpic, sicer, fp4, swembl, csv, report]. Default: macs', type="character", choices=c("raw","bed","narrow","macs","bayes","tpic","sicer","fp4","swembl","csv","report"), default="macs")
+
+    parser$add_argument("-c1", "--condition1",   help='Condition 1 name, single word with letters and numbers only. Default: condition_1', type="character", default="condition_1")
+    parser$add_argument("-c2", "--condition2",   help='Condition 2 name, single word with letters and numbers only. Default: condition_2', type="character", default="condition_2")
+    parser$add_argument("-me", "--method",       help='Method by which to analyze differential binding affinity. Default: all', type="character", choices=c("edger","deseq2","all"), default="all")
+    parser$add_argument("-mo", "--minoverlap",   help='Min peakset overlap. Only include peaks in at least this many peaksets when generating consensus peakset. Default: 2', type="integer", default=2)
+    parser$add_argument("-uc", "--usecommon",    help='Derive consensus peaks only from the common peaks within each condition. Min peakset overlap and min read counts are ignored. Default: false', action='store_true')
+    parser$add_argument(
+        "--summits",
+        help=paste(
+            "Width in bp to extend peaks around their summits in both directions",
+            "and replace the original ones. Set it to 100 bp for ATAC-Seq and 200",
+            "bp for ChIP-Seq datasets. To skip peaks extension and replacement, set",
+            "it to negative value. Default: 200 bp (results in 401 bp wide peaks)"
+        ),
+        type="integer", default=200
+    )
+    parser$add_argument("-cu", "--cutoff",       help='Cutoff for reported results. Applied to the parameter set with -cp. Default: 0.05', type="double",    default=0.05)
+    parser$add_argument("-cp", "--cparam",       help='Parameter to which cutoff should be applied (fdr or pvalue). Default: fdr',         type="character", choices=c("pvalue","fdr"), default="fdr")
+
+    parser$add_argument("-co", "--color",        help='Color scheme. Default: Greens', type="character", choices=c("Reds", "Greens", "Blues", "Greys", "YlOrRd", "Oranges"), default="Greens")
+    parser$add_argument("-th", "--threads",      help='Threads to use',                                     type="integer",   default=1)
+    parser$add_argument("-pa", "--padding",      help='Padding for generated heatmaps. Default: 20',        type="integer",   default=20)
+    parser$add_argument("-o",  "--output",       help='Output prefix. Default: diffbind',                   type="character", default="./diffbind")
+    args <- assert_args(parser$parse_args(commandArgs(trailingOnly = TRUE)))
+    return (args)
+}
+
+
+args <- get_args()
+
+
+diff_dba <- NULL
+for (i in 1:length(args$read1)){
+    diff_dba <- load_data_set(diff_dba, args$peak1[i], args$read1[i], args$name1[i], args$condition1, args$peakformat, i, args$block)
+}
+for (i in 1:length(args$read2)){
+    diff_dba <- load_data_set(diff_dba, args$peak2[i], args$read2[i], args$name2[i], args$condition2, args$peakformat, i, args$block)
+}
+
+
+diff_dba$config$cores <- args$threads
+
+
+cat("\nLoaded data\n - chrM removed\n - intersected peaks merged\n\n")
+print(diff_dba)
+
+
+mask_cond_1 <- dba.mask(diff_dba, attribute=DBA_CONDITION, value=args$condition1)
+mask_cond_2 <- dba.mask(diff_dba, attribute=DBA_CONDITION, value=args$condition2)
+mask_cond_both <- as.logical(mask_cond_1 + mask_cond_2)
+
+if (args$usecommon){
+    cat("\nDeriving consensus peaks only from the common peaks within each condition. Min peakset overlap is ignored.\n")
+    diff_dba_consensus <- dba.peakset(diff_dba, consensus=DBA_CONDITION, minOverlap=0.99)  # use 0.99 to include all intersected peaks within condition
+    diff_dba_consensus <- dba(diff_dba_consensus, mask=diff_dba_consensus$masks$Consensus, minOverlap=args$minoverlap)
+    cat("\nDerived consensus data\n - intersected peaks merged\n\n")
+    print(diff_dba_consensus)
+    consensus_peaks <- dba.peakset(diff_dba_consensus, bRetrieve=TRUE, minOverlap=args$minoverlap)
+    cat("\nConsensus peaks\n\n")
+    print(consensus_peaks)
+    export_consensus_peak_venn_diagram(diff_dba_consensus, paste(args$output, "_consensus_peak_venn_diagram", sep=""))
+}
+
+
+# Get peak overlap rates, export plots
+cat("\n")
+cat(paste("\nPeak overlap rate for", args$condition1, "\n", sep=" "))
+peak_overlap_rate_cond_1 = dba.overlap(diff_dba, mask=mask_cond_1, mode=DBA_OLAP_RATE)
+print(peak_overlap_rate_cond_1)
+
+cat(paste("\nPeak overlap rate for", args$condition2, "\n", sep=" "))
+peak_overlap_rate_cond_2 = dba.overlap(diff_dba, mask=mask_cond_2, mode=DBA_OLAP_RATE)
+print(peak_overlap_rate_cond_2)
+
+export_peak_overlap_rate_plot(peak_overlap_rate_cond_1, paste(args$output, "_condition_1_peak_overlap_rate", sep=""))
+export_peak_overlap_rate_plot(peak_overlap_rate_cond_2, paste(args$output, "_condition_2_peak_overlap_rate", sep=""))
+
+if (!args$usecommon){
+    peak_overlap_rate_all = dba.overlap(diff_dba, mode=DBA_OLAP_RATE)
+    cat("\n\nPeak overlap rate for all peaksets\n")
+    print(peak_overlap_rate_all)
+    export_peak_overlap_rate_plot(peak_overlap_rate_all, paste(args$output, "_all_peak_overlap_rate", sep=""))
+}
+
+
+# Export peak overlap correlation heatmap
+export_peak_overlap_correlation_heatmap(diff_dba, paste(args$output, "_peak_overlap_correlation_heatmap", sep=""), args$padding, args$color)
+
+
+# Count reads in binding site intervals
+cat(paste("\n\nCount reads using", diff_dba$config$cores, "threads. Min peakset overlap is set to", args$minoverlap, "\n", sep=" "))
+
+if (args$usecommon){
+    diff_dba <- dba.count(
+        diff_dba,
+        peaks=consensus_peaks,
+        summits=ifelse(args$summits >= 0, args$summits, FALSE),
+        minOverlap=args$minoverlap
+    )
+} else {
+    diff_dba <- dba.count(
+        diff_dba,
+        summits=ifelse(args$summits >= 0, args$summits, FALSE),
+        minOverlap=args$minoverlap
+    )
+}
+
+cat("\nCounted data\n\n")
+print(diff_dba)
+
+
+# Export raw counts correlation heatmap
+export_raw_counts_correlation_heatmap(diff_dba, paste(args$output, "_raw_counts_correlation_heatmap", sep=""), args$padding, args$color)
+
+
+# Export consensus peak venn diagram
+if (!args$usecommon){
+    export_consensus_peak_venn_diagram(diff_dba, paste(args$output, "_consensus_peak_venn_diagram", sep=""))
+}
+
+
+# Establish contrast
+metadata = dba.show(diff_dba)
+diff_dba$contrasts <- NULL
+cat(paste("\n\nEstablish contrast [", paste(metadata[metadata["Condition"]==args$condition1, "ID"], collapse=", "), "] vs [", paste(metadata[metadata["Condition"]==args$condition2, "ID"], collapse=", "), "]", "\n\n", sep=""))
+if (is.vector(args$block)){
+    cat(paste("Blocked attributes [", paste(metadata[args$block, "ID"], collapse=", "), "]", "\n\n", sep=""))
+    diff_dba <- dba.contrast(diff_dba, group1=mask_cond_1, group2=mask_cond_2, name1=args$condition1, name2=args$condition2, block=args$block)
+} else {
+    cat("Blocked attributes\n")
+    print(args$block)
+    cat("\n")
+    diff_dba <- dba.contrast(diff_dba, group1=mask_cond_1, group2=mask_cond_2, name1=args$condition1, name2=args$condition2, block=DBA_TISSUE)
+}
+
+
+diff_dba <- dba.analyze(diff_dba, method=args$method)
+
+
+cat("\nAnalyzed data\n\n")
+print(diff_dba)
+
+
+# Export all normalized counts correlation heatmaps
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_all_normalized_counts_correlation_heatmap_deseq", sep=""),
+                                             DBA_DESEQ2,
+                                             args$padding,
+                                             args$color)
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_all_normalized_counts_correlation_heatmap_deseq_block", sep=""),
+                                             DBA_DESEQ2_BLOCK,
+                                             args$padding,
+                                             args$color)
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_all_normalized_counts_correlation_heatmap_edger", sep=""),
+                                             DBA_EDGER,
+                                             args$padding,
+                                             args$color)
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_all_normalized_counts_correlation_heatmap_edger_block", sep=""),
+                                             DBA_EDGER_BLOCK,
+                                             args$padding,
+                                             args$color)
+
+
+# Export filtered normalized counts correlation heatmaps
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_filtered_normalized_counts_correlation_heatmap_deseq", sep=""),
+                                             DBA_DESEQ2,
+                                             args$padding,
+                                             args$color,
+                                             args$cutoff,
+                                             args$cparam)
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_filtered_normalized_counts_correlation_heatmap_deseq_block", sep=""),
+                                             DBA_DESEQ2_BLOCK,
+                                             args$padding,
+                                             args$color,
+                                             args$cutoff,
+                                             args$cparam)                                             
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_filtered_normalized_counts_correlation_heatmap_edger", sep=""),
+                                             DBA_EDGER,
+                                             args$padding,
+                                             args$color,
+                                             args$cutoff,
+                                             args$cparam)
+export_normalized_counts_correlation_heatmap(diff_dba,
+                                             paste(args$output, "_filtered_normalized_counts_correlation_heatmap_edger_block", sep=""),
+                                             DBA_EDGER_BLOCK,
+                                             args$padding,
+                                             args$color,
+                                             args$cutoff,
+                                             args$cparam)
+
+
+# Export filtered binding heatmaps
+export_binding_heatmap(diff_dba,
+                       paste(args$output, "_filtered_binding_heatmap_deseq", sep=""),
+                       DBA_DESEQ2,
+                       args$padding,
+                       args$color,
+                       args$cutoff,
+                       args$cparam)
+export_binding_heatmap(diff_dba,
+                       paste(args$output, "_filtered_binding_heatmap_deseq_block", sep=""),
+                       DBA_DESEQ2_BLOCK,
+                       args$padding,
+                       args$color,
+                       args$cutoff,
+                       args$cparam)
+export_binding_heatmap(diff_dba,
+                       paste(args$output, "_filtered_binding_heatmap_edger", sep=""),
+                       DBA_EDGER,
+                       args$padding,
+                       args$color,
+                       args$cutoff,
+                       args$cparam)
+export_binding_heatmap(diff_dba,
+                       paste(args$output, "_filtered_binding_heatmap_edger_block", sep=""),
+                       DBA_EDGER_BLOCK,
+                       args$padding,
+                       args$color,
+                       args$cutoff,
+                       args$cparam)
+
+
+# Export not filtered PCA plots
+export_pca_plot(diff_dba,
+                paste(args$output, "_all_pca_plot_deseq", sep=""),
+                DBA_DESEQ2)
+export_pca_plot(diff_dba,
+                paste(args$output, "_all_pca_plot_deseq_block", sep=""),
+                DBA_DESEQ2_BLOCK)
+export_pca_plot(diff_dba,
+                paste(args$output, "_all_pca_plot_edger", sep=""),
+                DBA_EDGER)
+export_pca_plot(diff_dba,
+                paste(args$output, "_all_pca_plot_edger_block", sep=""),
+                DBA_EDGER_BLOCK)
+
+
+# Export filtered PCA plots
+export_pca_plot(diff_dba,
+                paste(args$output, "_filtered_pca_plot_deseq", sep=""),
+                DBA_DESEQ2,
+                args$cutoff,
+                args$cparam)
+export_pca_plot(diff_dba,
+                paste(args$output, "_filtered_pca_plot_deseq_block", sep=""),
+                DBA_DESEQ2_BLOCK,
+                args$cutoff,
+                args$cparam)
+export_pca_plot(diff_dba,
+                paste(args$output, "_filtered_pca_plot_edger", sep=""),
+                DBA_EDGER,
+                args$cutoff,
+                args$cparam)
+export_pca_plot(diff_dba,
+                paste(args$output, "_filtered_pca_plot_edger_block", sep=""),
+                DBA_EDGER_BLOCK,
+                args$cutoff,
+                args$cparam)
+
+
+# Export filtered MA plot
+export_ma_plot(diff_dba,
+               paste(args$output, "_filtered_ma_plot_deseq", sep=""),
+               DBA_DESEQ2,
+               args$cutoff,
+               args$cparam)
+export_ma_plot(diff_dba,
+               paste(args$output, "_filtered_ma_plot_deseq_block", sep=""),
+               DBA_DESEQ2_BLOCK,
+               args$cutoff,
+               args$cparam)
+export_ma_plot(diff_dba,
+               paste(args$output, "_filtered_ma_plot_edger", sep=""),
+               DBA_EDGER,
+               args$cutoff,
+               args$cparam)
+export_ma_plot(diff_dba,
+               paste(args$output, "_filtered_ma_plot_edger_block", sep=""),
+               DBA_EDGER_BLOCK,
+               args$cutoff,
+               args$cparam)
+
+
+# Export filtered volcano plots
+export_volcano_plot(diff_dba,
+                    paste(args$output, "_filtered_volcano_plot_deseq", sep=""),
+                    DBA_DESEQ2,
+                    args$cutoff,
+                    args$cparam)
+export_volcano_plot(diff_dba,
+                    paste(args$output, "_filtered_volcano_plot_deseq_block", sep=""),
+                    DBA_DESEQ2_BLOCK,
+                    args$cutoff,
+                    args$cparam)
+export_volcano_plot(diff_dba,
+                    paste(args$output, "_filtered_volcano_plot_edger", sep=""),
+                    DBA_EDGER,
+                    args$cutoff,
+                    args$cparam)
+export_volcano_plot(diff_dba,
+                    paste(args$output, "_filtered_volcano_plot_edger_block", sep=""),
+                    DBA_EDGER_BLOCK,
+                    args$cutoff,
+                    args$cparam)
+
+
+# Export filtered box plots
+export_box_plot(diff_dba,
+                paste(args$output, "_filtered_box_plot_deseq", sep=""),
+                DBA_DESEQ2,
+                args$cutoff,
+                args$cparam)
+export_box_plot(diff_dba,
+                paste(args$output, "_filtered_box_plot_deseq_block", sep=""),
+                DBA_DESEQ2_BLOCK,
+                args$cutoff,
+                args$cparam)
+export_box_plot(diff_dba,
+                paste(args$output, "_filtered_box_plot_edger", sep=""),
+                DBA_EDGER,
+                args$cutoff,
+                args$cparam)
+export_box_plot(diff_dba,
+                paste(args$output, "_filtered_box_plot_edger_block", sep=""),
+                DBA_EDGER_BLOCK,
+                args$cutoff,
+                args$cparam)
+
+
+# Export filtered results
+export_results(diff_dba,
+               paste(args$output, "_filtered_report_deseq.tsv", sep=""),
+               DBA_DESEQ2,
+               args$cutoff,
+               args$cparam)
+export_results(diff_dba,
+               paste(args$output, "_filtered_report_deseq_block.tsv", sep=""),
+               DBA_DESEQ2_BLOCK,
+               args$cutoff,
+               args$cparam)
+export_results(diff_dba,
+               paste(args$output, "_filtered_report_edger.tsv", sep=""),
+               DBA_EDGER,
+               args$cutoff,
+               args$cparam)
+export_results(diff_dba,
+               paste(args$output, "_filtered_report_edger_block.tsv", sep=""),
+               DBA_EDGER_BLOCK,
+               args$cutoff,
+               args$cparam)
+
+
+# Export not filtered results
+export_results(diff_dba,
+               paste(args$output, "_all_report_deseq.tsv", sep=""),
+               DBA_DESEQ2)
+export_results(diff_dba,
+               paste(args$output, "_all_report_deseq_block.tsv", sep=""),
+               DBA_DESEQ2_BLOCK)
+export_results(diff_dba,
+               paste(args$output, "_all_report_edger.tsv", sep=""),
+               DBA_EDGER)
+export_results(diff_dba,
+               paste(args$output, "_all_report_edger_block.tsv", sep=""),
+               DBA_EDGER_BLOCK)

--- a/dockerfiles/scripts/run_diffbind_manual.R
+++ b/dockerfiles/scripts/run_diffbind_manual.R
@@ -1,0 +1,1407 @@
+#!/usr/bin/env Rscript
+options(warn=-1)
+options(width=200)
+options(scipen=999)
+options(error=function(){traceback(3); quit(save="no", status=1, runLast=FALSE)})
+
+suppressMessages(library(cmapR))
+suppressMessages(library(dplyr))
+suppressMessages(library(Glimma))
+suppressMessages(library(hopach))
+suppressMessages(library(ggpubr))
+suppressMessages(library(ggplot2))
+suppressMessages(library(forcats))
+suppressMessages(library(argparse))
+suppressMessages(library(DiffBind))
+suppressMessages(library(tidyverse))
+suppressMessages(library(htmlwidgets))
+suppressMessages(library(BiocParallel))
+suppressMessages(library(GenomicRanges))
+suppressMessages(library(EnhancedVolcano))
+
+
+theme_set(theme_classic())                       # set classic theme for all ggplot generated graphics
+
+
+D40_COLORS <- c("#FF6E6A", "#71E869", "#6574FF", "#F3A6B5", "#FF5AD6", "#6DDCFE", "#FFBB70", "#43A14E", "#D71C7C", "#E1E333", "#8139A8", "#00D8B6", "#B55C00", "#7FA4B6", "#FFA4E3", "#B300FF", "#9BC4FD", "#FF7E6A", "#9DE98D", "#BFA178", "#E7C2FD", "#8B437D", "#ADCDC0", "#FE9FA4", "#FF53D1", "#D993F9", "#FF47A1", "#FFC171", "#625C51", "#4288C9", "#9767D4", "#F2D61D", "#8EE6FD", "#B940B1", "#B2D5F8", "#9AB317", "#C70000", "#AC8BAC", "#D7D1E4", "#9D8D87")
+ALL_CRITERIA <- c("Tissue", "Factor", "Condition", "Treatment", "Replicate")
+
+
+get_file_type <- function (filename){
+    ext = tools::file_ext(filename)
+    separator = "\t"
+    if (ext == "csv"){
+        separator = ","
+    }
+    return (separator)
+}
+
+
+get_metadata <- function(args){
+    dba_metadata <- read.table(
+        args$metadata,
+        sep=get_file_type(args$metadata),
+        header=TRUE,
+        check.names=FALSE,
+        stringsAsFactors=FALSE
+    )  %>% dplyr::rename("SampleID"=1) %>% mutate_at(colnames(.)[2:length(colnames(.))], factor)
+
+    if (!is.null(args$base)){
+        print(
+            paste(
+                "Attempting to relevel metadata table based on",
+                paste(args$base, collapse=", "), "values"
+            )
+        )
+        for (i in 1:length(args$base)) {
+            current_base_level <- args$base[i]
+            tryCatch(
+                expr = {
+                    current_column <- colnames(dba_metadata)[i+1]
+                    dba_metadata[[current_column]] <- relevel(dba_metadata[[current_column]], current_base_level)
+                    print(paste("Setting", current_base_level, "as a base level for", current_column))
+                },
+                error = function(e){
+                    print(
+                        paste(
+                            "Failed to set", current_base_level, "as a base level",
+                            "due to", e
+                        )
+                    )
+                }
+            )
+        }
+    }
+
+    raw_metadata <- dba_metadata %>%                     # need it for an easier access
+                    remove_rownames() %>%
+                    column_to_rownames("SampleID")
+    print("Raw metadata")
+    print(raw_metadata)
+
+    all_metadata_vars <- unique(colnames(raw_metadata))
+    if(length(intersect(all_metadata_vars, ALL_CRITERIA)) != length(all_metadata_vars)){
+        print("Metadata includes not supported column names")
+        quit(save = "no", status = 1, runLast = FALSE)
+    }
+
+    locations_df <- data.frame(
+        SampleID=args$aliases,
+        bamReads=args$alignments,
+        Peaks=args$peaks,
+        check.names=FALSE
+    )
+    
+    if (!all(sort(dba_metadata$SampleID) == sort(unique(locations_df$SampleID)))){
+        print("Metadata file is malformed. Exiting.")
+        quit(save="no", status=1, runLast=FALSE)
+    }
+    dba_metadata <- dba_metadata %>% dplyr::left_join(locations_df, by="SampleID")
+    print("DBA metadata")
+    print(dba_metadata)
+
+    return (list(raw=raw_metadata, dba=dba_metadata))
+}
+
+
+get_contrast <- function(design_formula, metadata, args){
+    model <- model.matrix(design_formula, metadata)
+    print("Model matrix")
+    print(model)
+    for (i in 1:length(colnames(metadata))){
+        current_column <- colnames(metadata)[i]
+        unique_keys <- unique(metadata[[current_column]])
+        for (j in 1:length(unique_keys)){
+            key <- as.character(unique_keys[j])
+            print(paste("Subsetting model matrix for", current_column, "column", "with value", key))
+            subset <- colMeans(model[metadata[[current_column]] == key, ])
+            print(subset)
+            assign(key, subset)
+        }
+    }
+    print(paste("Evaluating contrast", args$contrast))
+    contrast <- eval(parse(text=args$contrast))
+    print(contrast)
+    return (contrast)
+}
+
+
+get_clustered_data <- function(data, center, dist, transpose) {
+
+    if (transpose){
+        print("Transposing expression data")
+        data = t(data)
+    }
+    if (!is.null(center)) {
+        print(paste("Centering expression data by ", center, sep=""))
+        if (center == "mean"){
+            data = data - rowMeans(data)    
+        } else {
+            data = data - rowMedians(data.matrix(data))    
+        }
+    }
+    print("Creating distance matrix")
+    distance_matrix <- distancematrix(data, dist)
+    print("Running HOPACH")
+    hopach_results <- hopach(data, dmat=distance_matrix)
+
+    if (transpose){
+        print("Transposing expression data")
+        data = t(data)
+    }
+
+    print("Parsing cluster labels")
+    options(scipen=999)                                           # need to temporary disable scientific notation, because nchar gives wrong answer
+    clusters = as.data.frame(hopach_results$clustering$labels)
+    colnames(clusters) = "label"
+    clusters = cbind(
+        clusters,
+        "HCL"=outer(
+            clusters$label,
+            10^c((nchar(trunc(clusters$label))[1]-1):0),
+            function(a, b) {
+                paste0("c", a %/% b)
+            }
+        )
+    )
+    clusters = clusters[, c(-1), drop=FALSE]
+    options(scipen=0)                                            # setting back to the default value
+
+    return (
+        list(
+            order=as.vector(hopach_results$clustering$order),
+            counts=data,
+            clusters=clusters
+        )
+    )
+}
+
+
+export_gct <- function(counts_mat, row_metadata, col_metadata, location){
+    tryCatch(
+        expr = {
+            row_metadata <- row_metadata %>% rownames_to_column("id") %>% mutate_at("id", as.vector)
+            col_metadata <- col_metadata %>% rownames_to_column("id") %>% mutate_at("id", as.vector)
+            gct_data <- new(
+                "GCT",
+                mat=counts_mat[row_metadata$id, col_metadata$id],       # to guarantee the order and number of row/columns
+                rdesc=row_metadata,
+                cdesc=col_metadata
+            )
+            write_gct(
+                ds=gct_data,
+                ofile=location,
+                appenddim=FALSE
+            )
+            print(paste("Exporting GCT data to", location, sep=" "))
+        },
+        error = function(e){
+            print(paste("Failed to export GCT data to", location, sep=" "))
+        }
+    )
+}
+
+
+export_data <- function(data, location, row_names=FALSE, col_names=TRUE, quote=FALSE, digits=NULL){
+    tryCatch(
+        expr = {
+            if (!is.null(digits)){
+                data <- format(data, digits=digits)
+            }
+            data <- data %>%                                             # to remove leading and trailing spaces when exporting to TSV
+                    mutate(across(everything(), as.character)) %>%
+                    mutate(across(everything(), str_trim))
+            write.table(
+                data,
+                file=location,
+                sep=get_file_type(location),
+                row.names=row_names,
+                col.names=col_names,
+                quote=quote
+            )
+            print(paste("Export data to", location, sep=" "))
+        },
+        error = function(e){
+            print(paste("Failed to export data to", location, sep=" "))
+        }
+    )
+}
+
+
+export_overlap_plot <- function(data, rootname, plot_title, plot_subtitle, highlight=NULL, pdf=FALSE, width=600, height=600, resolution=100){
+    tryCatch(
+        expr = {
+            colors <- rep("darkseagreen", length(data))
+            if(!is.null(highlight) && highlight > 0 && highlight <= length(data)){
+                colors[highlight] <- "darkseagreen4"
+            }
+            peaksets <- factor(
+                as.character(1:length(data)),                   # need to have it as character, otherwise some labels will be skipped,
+                levels=as.character(1:length(data))             # but the levels shouldn't be alphabetical, so we force the proper order
+            )
+            data_df <- data.frame(
+                overlaps=data,
+                peaksets=peaksets,
+                color=colors,
+                check.names=FALSE
+            )
+            vjust <- 1.6
+            hjust <- 0.5
+            angle <- 0
+            if(length(data) > 5){
+                vjust <- 0.5
+                hjust <- -0.2
+                angle <- 90
+            }
+            plot <- ggplot(data_df, aes(x=peaksets, y=overlaps, fill=peaksets)) +
+                    geom_bar(stat="identity", show.legend=FALSE) +
+                    scale_fill_manual(values=data_df$color) +
+                    geom_text(
+                        aes(label=scales::comma(overlaps)),
+                        vjust=vjust,
+                        hjust=hjust,
+                        angle=angle,
+                        y=0,
+                        color="darkblue", size=3.5
+                    ) +
+                    xlab("Min peakset overlap") +
+                    ylab("Number of consensus peaks") +
+                    ggtitle(plot_title, subtitle=plot_subtitle)
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=resolution)
+            suppressMessages(print(plot))
+            dev.off()
+
+            if (!is.null(pdf) && pdf) {
+                pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/resolution), height=round(height/resolution))
+                suppressMessages(print(plot))
+                dev.off()
+            }
+
+            print(paste("Exporting overlap plot to ", rootname, ".(png/pdf)", sep=""))
+
+        },
+        error = function(e){
+            tryCatch(expr={dev.off()}, error=function(e){})
+            print(
+                paste0(
+                    "Failed to export overlap plot to ", rootname,
+                    ".(png/pdf) with error - ", e
+                )
+            )
+        }
+    )
+}
+
+
+export_corr_heatmap <- function(data, rootname, plot_title, score=NULL, padj=1, colors="Greens", pdf=FALSE, margin=20, width=800, height=800, resolution=100){
+    tryCatch(
+        expr = {
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=resolution)
+            if (!is.null(score)){
+                dba.plotHeatmap(dba_data, correlations=TRUE, th=padj, score=score, main=plot_title, colScheme=colors, margin=margin, density.info="none")
+            } else {
+                print("Correlation values")
+                print(dba.plotHeatmap(dba_data, correlations=TRUE, breaks=seq(0, 1, length.out=257), th=padj, main=plot_title, colScheme=colors, margin=margin, density.info="none"))
+            }
+            dev.off()
+
+            if (!is.null(pdf) && pdf) {
+                pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/resolution), height=round(height/resolution))
+                if (!is.null(score)){
+                    dba.plotHeatmap(dba_data, correlations=TRUE, th=padj, score=score, main=plot_title, colScheme=colors, margin=margin, density.info="none")
+                } else {
+                    dba.plotHeatmap(dba_data, correlations=TRUE, breaks=seq(0, 1, length.out=257), th=padj, main=plot_title, colScheme=colors, margin=margin, density.info="none")
+                }
+                dev.off()
+            }
+
+            print(paste("Exporting correlation heatmap to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            tryCatch(expr={dev.off()}, error=function(e){})
+            print(
+                paste0(
+                    "Failed to export correlation heatmap to ", rootname,
+                    ".(png/pdf) with error - ", e
+                )
+            )
+        }
+    )
+}
+
+
+export_profile_heatmap <- function(data, rootname, sites, samples=NULL, scores="rank", abs_scores=FALSE, decreasing=TRUE, split_by=NULL, max_sites=1000, colors=c("black", "yellow"), pdf=FALSE, width=800, height=800, resolution=100){
+    tryCatch(
+        expr = {
+
+            profiles_data <- dba.plotProfile(
+                data,
+                sites=sites,
+                samples=samples,                      # used only when computing profile, not building the plot
+                scores=scores,
+                absScores=abs_scores,
+                maxSites=max_sites,
+                matrices_color=colors,
+                decreasing=decreasing,
+                merge=NULL
+            )
+
+            if(!is.null(split_by)){                   # used only to fix a bug with not proper Binding Sites groups order and names
+                rowData(profiles_data)$"Binding Sites" <- factor(
+                    as.vector(as.character(rowData(profiles_data)[[split_by]])),
+                    levels=names(sites)               # to make sure the order of clusters is correct, because sites now is GRangesList split by cluster
+                )
+            }
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=resolution)
+            dba.plotProfile(
+                profiles_data,
+                scores=scores,
+                absScores=abs_scores,
+                maxSites=max_sites,
+                matrices_color=colors,
+                decreasing=decreasing,
+                merge=NULL
+            )
+            dev.off()
+
+            if (!is.null(pdf) && pdf) {
+                pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/resolution), height=round(height/resolution))
+                dba.plotProfile(
+                    profiles_data,
+                    scores=scores,
+                    absScores=abs_scores,
+                    maxSites=max_sites,
+                    matrices_color=colors,
+                    decreasing=decreasing,
+                    merge=NULL
+                )
+                dev.off()
+            }
+
+            print(paste("Exporting profile heatmap to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            tryCatch(expr={dev.off()}, error=function(e){})
+            print(
+                paste0(
+                    "Failed to export profile heatmap to ", rootname,
+                    ".(png/pdf) with error - ", e
+                )
+            )
+        }
+    )
+}
+
+
+export_ma_plot <- function(data, rootname, fdr_cutoff, y_cutoff, x_label, y_label, plot_title, plot_subtitle, caption, pdf=FALSE, width=800, height=800, resolution=100){
+    tryCatch(
+        expr = {
+            plot <- ggmaplot(data,
+                        fdr=fdr_cutoff,
+                        fc=y_cutoff,
+                        top=0,
+                        size=2,
+                        alpha=0.6,
+                        main=plot_title,
+                        subtitle=plot_subtitle,
+                        caption=caption,
+                        xlab=x_label,
+                        ylab=y_label,
+                        palette=c("red", "red", "grey30")
+                    ) +
+                    theme_classic() +
+                    theme(legend.position="none", plot.subtitle=element_text(size=8, face="italic", color="gray30"))
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=resolution)
+            suppressMessages(print(plot))
+            dev.off()
+
+            if (!is.null(pdf) && pdf) {
+                pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/resolution), height=round(height/resolution))
+                suppressMessages(print(plot))
+                dev.off()
+            }
+
+            print(paste("Exporting MA-plot to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            tryCatch(expr={dev.off()}, error=function(e){})
+            print(
+                paste0(
+                    "Failed to export MA-plot to ", rootname,
+                    ".(png/pdf) with error - ", e
+                )
+            )
+        }
+    )
+}
+
+
+export_volcano_plot <- function(data, rootname, x_axis, y_axis, x_cutoff, y_cutoff, x_label, y_label, plot_title, plot_subtitle, caption, features=NA, pdf=FALSE, width=1200, height=800, resolution=100){
+    tryCatch(
+        expr = {
+            plot <- EnhancedVolcano(
+                        data,
+                        x=x_axis,
+                        y=y_axis,
+                        lab=rownames(data),
+                        selectLab=features,
+                        FCcutoff=x_cutoff,
+                        pCutoff=y_cutoff,
+                        xlab=x_label,
+                        ylab=y_label,
+                        title=plot_title,
+                        subtitle=plot_subtitle,
+                        caption=caption,
+                        labSize=4,
+                        labFace="bold",
+                        labCol="red4",
+                        colAlpha=0.6,
+                        col=c("grey30", "grey30", "grey30", "red"),
+                        drawConnectors=TRUE,
+                        widthConnectors=0.75
+                    ) +
+                    scale_y_log10() + annotation_logticks(sides="l", alpha=0.3) +
+                    theme_classic() +
+                    theme(legend.position="none", plot.subtitle=element_text(size=8, face="italic", color="gray30"))
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=resolution)
+            suppressMessages(print(plot))
+            dev.off()
+
+            if (pdf) {
+                pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/resolution), height=round(height/resolution))
+                suppressMessages(print(plot))
+                dev.off()
+            }
+
+            print(paste("Export volcano plot to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            tryCatch(expr={dev.off()}, error=function(e){})
+            print(paste("Failed to export volcano plot to ", rootname, ".(png/pdf) with error - ", e, sep=""))
+        }
+    )
+}
+
+
+export_mds_html_plot <- function(data, groups, location){
+    tryCatch(
+        expr = {
+            saveWidget(
+                glimmaMDS(
+                    x=data,
+                    groups=groups,
+                    labels=rownames(groups)
+                ),
+                file=location
+            )
+        },
+        error = function(e){
+            print(paste0("Failed to export MDS plot to ", location, " with error - ", e))
+        }
+    )
+}
+
+
+get_pca_data <- function(counts_data){
+    tryCatch(
+        expr = {
+            print("Computing PCA for counts data")
+            counts_data <- counts_data %>%
+                           filter_all(any_vars(. != 0))   # remove rows with only zeros, otherwise prcomp may fail
+            pca_raw <- prcomp(
+                t(counts_data),
+                center=TRUE,
+                scale.=TRUE
+            )
+            pca_scores <- as.data.frame(pca_raw$x) %>%
+                          rownames_to_column(var="group")
+            pca_variance <- round(pca_raw$sdev / sum(pca_raw$sdev) * 100, 2)
+            return (list(scores=pca_scores, variance=pca_variance))
+        },
+        error = function(e){
+            print(paste("Failed to compute PCA for counts data due to", e))
+        }
+    )
+}
+
+
+export_pca_plot <- function(data, pcs, rootname, plot_title, legend_title, color_by="label", label_size=5, pt_size=8, pt_shape=19, alpha=0.75, palette_colors=D40_COLORS, pdf=FALSE, width=1200, height=800, resolution=100){
+    tryCatch(
+        expr = {
+            x_score_column <- paste0("PC", pcs[1])
+            y_score_column <- paste0("PC", pcs[2])
+            x_variance <- data$variance[pcs[1]]
+            y_variance <- data$variance[pcs[2]]
+            plot <- ggplot(
+                        data$scores,
+                        aes_string(x=x_score_column, y=y_score_column, color=color_by)
+                    ) +
+                    geom_point(size=pt_size, shape=pt_shape, alpha=alpha) +
+                    xlab(paste0(x_score_column, ": ", x_variance, "% variance")) +
+                    ylab(paste0(y_score_column, ": ", y_variance, "% variance")) + 
+                    geom_label_repel(
+                        aes_string(label=color_by),
+                        size=label_size,
+                        point.padding=0.5,
+                        box.padding=0.5,
+                        check_overlap=TRUE,
+                        show.legend=FALSE
+                    ) +
+                    ggtitle(plot_title) +
+                    guides(color=guide_legend(legend_title)) +
+                    scale_color_manual(values=palette_colors) +
+
+            png(filename=paste(rootname, ".png", sep=""), width=width, height=height, res=resolution)
+            suppressMessages(print(plot))
+            dev.off()
+
+            if (!is.null(pdf) && pdf) {
+                pdf(file=paste(rootname, ".pdf", sep=""), width=round(width/resolution), height=round(height/resolution))
+                suppressMessages(print(plot))
+                dev.off()
+            }
+
+            print(paste("Exporting PCA plot to ", rootname, ".(png/pdf)", sep=""))
+        },
+        error = function(e){
+            tryCatch(expr={dev.off()}, error=function(e){})
+            print(paste("Failed to export PCA plot to ", rootname, ".(png/pdf) with error - ", e, sep=""))
+        }
+    )
+}
+
+
+export_plots <- function(data, metadata, args){
+    export_volcano_plot(
+        data=data,
+        x_axis="log2FoldChange",
+        y_axis="padj",
+        x_cutoff=0,
+        y_cutoff=args$padj,
+        x_label=bquote(~Log[2]~"fold change"),
+        y_label=bquote("-"~Log[10]~"padj"),
+        plot_title="Volcano plot for differentially bound sites",
+        plot_subtitle=paste0("Differentially bound sites with padj", "<=", args$padj),
+        caption=paste(nrow(data), "features"),
+        rootname=paste(args$output, "diff_vlcn", sep="_"),
+        pdf=args$pdf
+    )
+
+    export_ma_plot(
+        data=data,
+        fdr_cutoff=args$padj,
+        y_cutoff=0,
+        x_label=bquote(~Log[2]~"base mean"),
+        y_label=bquote(~Log[2]~"fold change"),
+        plot_title="MA-plot for differentially bound sites",
+        plot_subtitle=paste0("Differentially bound sites with padj", "<=", args$padj),
+        caption=paste(nrow(data), "features"),
+        rootname=paste(args$output, "diff_ma", sep="_"),
+        pdf=args$pdf
+    )
+
+    pca_data <- get_pca_data(data[, rownames(metadata)])               # adds 'group' column to identify the datasets
+
+    export_pca_plot(
+        data=pca_data,
+        pcs=c(1, 2),
+        plot_title="PCA (1,2) of not filtered normalized counts",
+        legend_title="Dataset",
+        color_by="group",
+        width=ifelse(length(args$aliases) > 13, 1600, 1200),       # need to make it wider if we have a lot of samples
+        rootname=paste(args$output, "nr_rds_pca_1_2", sep="_"),
+        pdf=args$pdf
+    )
+
+    export_pca_plot(
+        data=pca_data,
+        pcs=c(2, 3),
+        plot_title="PCA (2,3) of not filtered normalized counts",
+        legend_title="Dataset",
+        color_by="group",
+        width=ifelse(length(args$aliases) > 13, 1600, 1200),       # need to make it wider if we have a lot of samples
+        rootname=paste(args$output, "nr_rds_pca_2_3", sep="_"),
+        pdf=args$pdf
+    )
+
+    export_mds_html_plot(
+        data=as.matrix(data[, rownames(metadata)]),
+        groups=metadata,
+        location=paste(args$output, "nr_rds_mds.html", sep="_")
+    )
+}
+
+
+assert_args <- function(args){
+    if (length(args$alignments) != length(args$peaks) || length(args$alignments) != length(args$aliases)){
+        print("--alignments, --peaks and/or --aliases parameters have different number of values")
+        quit(save = "no", status = 1, runLast = FALSE)
+    }
+
+    if(args$method == "edger" && is.null(args$contrast)){
+        print("EdgeR can't be used without --contrast. Select DESeq2 or provide contrast.")
+        quit(save = "no", status = 1, runLast = FALSE)
+    }
+
+    args$method <- switch(
+        args$method,
+        "deseq2" = DBA_DESEQ2,
+        "edger"  = DBA_EDGER
+    )
+
+    args$scoreby <- switch(
+        args$scoreby,
+        "pvalue" = 7,           # -log10(pvalue)
+        "qvalue" = 9            # -log10(qvalue)
+    )
+
+    args$norm <- switch(
+        args$norm,
+        "auto" = DBA_NORM_NATIVE,
+        "rle"  = DBA_NORM_RLE,
+        "tmm"  = DBA_NORM_TMM,
+        "lib"  = DBA_NORM_LIB
+    )
+
+    print("Converting the --score parameter to -log10 form")
+    args$score <- -log10(args$score)             # need to convert it to -log10, as both pvalue and qvalue are -log10
+
+    all_design_vars <- unique(all.vars(as.formula(args$design)))
+    if(length(intersect(all_design_vars, ALL_CRITERIA)) != length(all_design_vars)){
+        print("--design parameter includes not supported values")
+        quit(save = "no", status = 1, runLast = FALSE)
+    }
+
+    if(!is.null(args$groupby)){
+        all_groupby_vars <- unique(args$groupby)
+        if(length(intersect(all_groupby_vars, ALL_CRITERIA)) != length(all_groupby_vars)){
+            print("--groupby parameter includes not supported values")
+            quit(save = "no", status = 1, runLast = FALSE)
+        }
+        dba_groupby <- c()
+        for (i in 1:length(all_groupby_vars)){
+            dba_groupby <- append(
+                dba_groupby,
+                switch(
+                    all_groupby_vars[i],
+                    "Tissue"     = DBA_TISSUE,
+                    "Factor"     = DBA_FACTOR,
+                    "Condition"  = DBA_CONDITION,
+                    "Treatment"  = DBA_TREATMENT,
+                    "Replicate"  = DBA_REPLICATE
+                )
+            )
+        }
+        args$groupby_names <- args$groupby
+        args$groupby_codes <- dba_groupby
+    }
+
+    return (args)
+}
+
+
+get_args <- function(){
+    parser <- ArgumentParser(description="DiffBind Multi-factor Analysis")
+    parser$add_argument(
+        "--alignments",
+        help="Sorted and indexed alignment files in bam format.",
+        type="character", required="True", nargs="+"
+    )
+    parser$add_argument(
+        "--peaks",
+        help=paste(
+            "Peak files in the MACS2 xls format. Number and order of the",
+            "files should correspond to the files provided in --alignments",
+            "parameter."
+        ),
+        type="character", required="True", nargs="+"
+    )
+    parser$add_argument(
+        "--aliases",
+        help=paste(
+            "Unique names for datasets provided in --alignments and --peaks",
+            "parameters, no special characters or spaces are allowed. Number",
+            "and order of the names should correspond to the values provided",
+            "in --alignments and --peaks parameters."
+        ),
+        type="character", required="True", nargs="+"
+    )
+    parser$add_argument(
+        "--metadata",
+        help=paste(
+            "TSV/CSV metadata file to describe datasets provided in --alignments",
+            "and --peaks parameters. First column should have the name 'sample',",
+            "all other columns names should be selected from the following list:",
+            "Tissue, Factor, Condition, Treatment, Replicate. The values from the",
+            "'sample' column should correspond to the values provided in --aliases",
+            "parameter. For a proper --contrast intepretation, values defined in",
+            "each metadata column should not be used in any of the other columns.",
+            "All metadata columns are treated as factors (no covariates are supported)."
+        ),
+        type="character", required="True"
+    )
+    parser$add_argument(
+        "--scoreby",
+        help=paste(
+            "Score metrics to exclude low quality peaks based on the",
+            "threshold provided in the --score parameter.",
+            "Default: pvalue"                                                              # https://support.bioconductor.org/p/66628/
+        ),
+        type="character",
+        choices=c("pvalue", "qvalue"),
+        default="pvalue"
+    )
+    parser$add_argument(
+        "--score",
+        help=paste(
+            "Filtering threshold to keep only those peaks where the metric selected",
+            "in --scoreby parameter is less than or equal to the provided value.",
+            "Default: 0.05"
+        ),
+        type="double", default=0.05
+    )
+    parser$add_argument(
+        "--minrpkm",
+        help=paste(
+            "Filtering threshold to keep only those peaks where the max RPKM for",         # in fact, this filter will be applied to DBA_SCORE_RPKM_MINUS,
+            "all datasets is bigger than or equal to the provided value. Default: 1"       # but we don't have any controls so it's the same as DBA_SCORE_RPKM 
+        ),
+        type="double", default=1
+    )
+    parser$add_argument(
+        "--summits",
+        help=paste(
+            "Width in bp to extend peaks around their summits in both directions",
+            "and replace the original ones. Set it to 100 bp for ATAC-Seq and 200",
+            "bp for ChIP-Seq datasets. To skip peaks extension and replacement, set",
+            "it to negative value. Default: 200 bp (results in 401 bp wide peaks)"
+        ),
+        type="integer", default=200
+    )
+    parser$add_argument(
+        "--minoverlap",
+        help=paste(
+            "Filtering threshold to keep only those peaks that are present in at",
+            "least this many datasets when generating consensus set of peaks used",
+            "in differential analysis. If this threshold has a value between zero",
+            "and one, only those peaks will be included that are present in at least",
+            "this proportion of datasets. When combined with --groupby parameter,",
+            "--minoverlap threshold is applied per group, then union of the resulted",
+            "peaks are used in the differential analysis. Default: 2"
+        ),
+        type="double", default=2
+    )
+    parser$add_argument(
+        "--groupby",
+        help=paste(
+            "Column(s) from the metadata table to define datasets grouping. --minoverlap",
+            "filtering threshold will be applied within each group independently. Union",
+            "of the resulted peaks from each of the groups will be used in the differential",
+            "analysis. Default: apply --minoverlap filtering threshold for all datasets",
+            "jointly"
+        ),
+        type="character", nargs="*"
+    )
+    parser$add_argument(
+        "--design",
+        help=paste(
+            "Design formula comprised of the metadata columns names.",
+            "It should start with ~."
+        ),
+        type="character", required="True"
+    )
+    parser$add_argument(
+        "--contrast",
+        help=paste(
+            "Contrast applied to the analysis results when calculating log2 fold changes.",
+            "It should be formatted as a mathematical formula of values present in the",
+            "metadata table. It is a required parameter if --method is set to edger. If not",
+            "provided and --method is set to deseq2, the last term from the design formula",
+            "will be used."
+        ),
+        type="character"
+    )
+    parser$add_argument(
+        "--base",
+        help=paste(
+            "Base levels for each of the metadata columns. Number and order of the provided",
+            "values should correspond to the metadata columns. Default: define base levels",
+            "alphabetically."
+        ),
+        type="character", nargs="*"
+    )
+    parser$add_argument(
+        "--method",
+        help=paste(
+            "Method used in the differential binding analysis. Should be equal to either edger",
+            "or deseq2. Default: deseq2"
+        ),
+        type="character", choices=c("edger", "deseq2"),
+        default="deseq2"
+    )
+    parser$add_argument(
+        "--norm",
+        help=paste(
+            "Normalization technique applied to the read counts before running differential",
+            "binding analysis. When set to auto selects rle for deseq2 and tmm for edger.",
+            "Default: auto"
+        ),
+        type="character", choices=c("auto", "rle", "tmm", "lib"),
+        default="auto"
+    )
+    parser$add_argument(
+        "--padj",
+        help=paste(
+            "Filtering threshold to report only differentially bound sites with adjusted",
+            "P-value less than or equal to the provided value. Default: 0.05"
+        ),
+        type="double", default=0.05
+    )
+    parser$add_argument(
+        "--cluster",
+        help=paste(
+            "Hopach clustering method to be run on normalized read counts. Default:",
+            "do not run clustering"
+        ),
+        type="character",
+        choices=c("row", "column", "both")
+    )
+    parser$add_argument(
+        "--rowdist",
+        help=paste(
+            "Distance metric for HOPACH row clustering. Ignored if --cluster is not",
+            "provided. Default: cosangle"
+        ),
+        type="character", default="cosangle",
+        choices=c("cosangle", "abscosangle", "euclid", "abseuclid", "cor", "abscor")
+    )
+    parser$add_argument(
+        "--columndist",
+        help=paste(
+            "Distance metric for HOPACH column clustering. Ignored if --cluster is not",
+            "provided. Default: euclid"
+        ),
+        type="character", default="euclid",
+        choices=c("cosangle", "abscosangle", "euclid", "abseuclid", "cor", "abscor")
+    )
+    parser$add_argument(
+        "--center",
+        help=paste(
+            "Apply mean centering for normalized read counts prior to running",
+            "clustering by row. Ignored when --cluster is not row or both.",
+            "Default: do not centered"
+        ),
+        action="store_true"
+    )
+    parser$add_argument(
+        "--pdf",
+        help="Export plots in PDF. Default: false",
+        action="store_true"
+    )
+    parser$add_argument(
+        "--output",
+        help=paste(
+            "Output prefix for generated files"
+        ),
+        type="character", default="./diffbind"
+    )
+    parser$add_argument(
+        "--cpus",
+        help="Number of cores/cpus to use. Default: 1",
+        type="integer", default=1
+    )
+    args <- assert_args(parser$parse_args(commandArgs(trailingOnly = TRUE)))
+    return (args)
+}
+
+
+# Parse arguments
+args <- get_args()
+
+print("Input parameters")
+print(args)
+
+print(paste("Loading metadata from", args$metadata))
+metadata <- get_metadata(args)
+
+# peaks will be filtered by --scoreby column to include only >= args$score values
+# We already transformed args$score to -log10, that's why we use >=
+# Scores column will be normalized from 0 to 1
+dba_default_params <- list(
+    minOverlap=1,                               # we should set it to 1, otherwise minOverlap is getting applied even when we load data
+    peakCaller="macs",                          # we don't set peakFormat and scoreCol as they will be derived from the peakCaller value
+    peakFormat="macs",
+    scoreCol=args$scoreby,                      # either 7 (-log10 pvalue) or 9 (-log10 qvalue)
+    filter=args$score,
+    bLowerScoreBetter=FALSE,                    # both score columns are -log10, so lower values are not better
+    config=list(                                # default config with certain parameters overwritten
+        AnalysisMethod=args$method,
+        th=args$padj,
+        DataType=DBA_DATA_FRAME,                # to return data as dataframe
+        RunParallel=TRUE, 
+        minQCth=15,
+        fragmentSize=125,                       # this value will be ignored when running dba.count with bUseSummarizeOverlaps=TRUE
+        bCorPlot=FALSE,
+        reportInit="DBA", 
+        bUsePval=FALSE,
+        design=TRUE,
+        doBlacklist=FALSE,
+        doGreylist=FALSE,
+        cores=args$cpus
+    )
+)
+
+print("Constructing DBA object. Forcing --minoverlap to 1")
+dba_data <- do.call(dba, append(dba_default_params, list(sampleSheet=metadata$dba)))
+print(
+    paste0(
+        "This DBA object includes merged with minOverlap=1 peaks ",
+        "preliminary filtered by ", args$scoreby, " column to ",
+        "contain only values >= ", args$score
+    )
+)
+print(dba_data)
+print(str(dba_data))
+
+sample_groups <- c(paste(metadata$dba$SampleID, collapse="@"))
+if(!is.null(args$groupby_names)){
+    sample_groups <- append(
+        sample_groups,
+        metadata$dba %>% dplyr::group_by(across(all_of(args$groupby_names))) %>%
+                         mutate(sample=paste(SampleID, collapse="@")) %>%
+                         ungroup() %>%
+                         select(sample) %>%
+                         distinct() %>%
+                         pull(sample)
+    )
+}
+print("Sample groups for peakset overlap rate plots")
+print(sample_groups)
+for (i in 1:length(sample_groups)){
+    current_samples <- unlist(strsplit(sample_groups[i], "@"))
+    print(
+        paste(
+            "Processing", paste(current_samples, collapse=", "),
+            "group of samples"
+        )
+    )
+    current_mask = c()
+    for (j in 1:length(current_samples)) {
+        current_mask <- append(
+            current_mask,
+            which(as.vector(as.character(metadata$dba$SampleID)) == current_samples[j])
+        )
+    }
+    export_overlap_plot(
+        data=dba.overlap(dba_data, mask=current_mask, mode=DBA_OLAP_RATE),
+        plot_title="Peakset overlap rate",
+        plot_subtitle=paste(current_samples, collapse=", "),
+        rootname=paste(args$output, "_pk_vrlp_s", i, sep=""),
+        pdf=args$pdf
+    )
+}
+
+# correlation heatmap is build based on the -log10(pvalue) or
+# -log10(qvalue) columns from the loaded peak files. All peaks
+# are added to the same list where the overlapping or adjacent
+# peaks are merged. If several peaks from the specific peakset
+# overlap the same merged peak, the best score is taken. If a
+# certain peakset doesn't include a peak that overlaps with the
+# merged peak, negative score is assigned.
+
+export_corr_heatmap(                              # how it is calculated https://support.bioconductor.org/p/63034/
+    data=dba_data,
+    plot_title="Datasets correlation (all peaks)",
+    rootname=paste(
+        args$output, "all_pk_scr_corr", sep="_"
+    ),
+    pdf=args$pdf
+)
+
+print("Counting reads in peaks")
+dba_count_default_params <- list(
+    DBA=dba_data,
+    bRemoveDuplicates=FALSE,                                  # set to FALSE because with bUseSummarizeOverlaps duplicates should be removed in advance
+    bUseSummarizeOverlaps=TRUE,                               # this is a default value but we set it here explicitely, fragmentSize will be ignored
+    summits=ifelse(args$summits >= 0, args$summits, FALSE),   # will make all consensus peaks have the same size 2*summits+1
+    filter=args$minrpkm,                                      # keep only those peaks where max RPKM for all datasets is bigger or equal to this value
+    bParallel=TRUE
+)
+
+if(!is.null(args$groupby_codes)){
+    print(
+        paste(
+            "Searching for the consensus peaks with minimum peakset overlap",
+            args$minoverlap, "applied to each dataset group separately"
+        )
+    )
+    dba_peakset_default_params <- list(
+        peak.caller="macs",
+        peak.format="macs",
+        scoreCol=args$scoreby,
+        bLowerScoreBetter=FALSE,
+        filter=args$score,
+        DataType=DBA_DATA_FRAME
+    )
+    dba_data_temp <- do.call(
+        dba.peakset,
+        append(
+            dba_peakset_default_params,
+            list(
+                DBA=dba_data,
+                consensus=args$groupby_codes,
+                minOverlap=args$minoverlap                               # applying --minoverlap per group
+            )
+        )
+    )
+    print("Temporary DBA object to obtain consensus peaks")
+    print(dba_data_temp)
+    print(str(dba_data_temp))
+
+    if (!("Consensus" %in% names(dba_data_temp$masks))){
+        print(
+            paste(
+                "--minoverlap parameter it too high for the provided --groupby",
+                "or each group ended up having exactly one dataset. Try to use",
+                "smaller --minoverlap or set it in a fraction form, alternatively,",
+                "update --groupby parameter."
+            )
+        )
+        quit(save = "no", status = 1, runLast = FALSE)
+    }
+
+    dba_data_temp <- do.call(
+        dba,
+        append(
+            dba_default_params,
+            list(
+                DBA=dba_data_temp,
+                mask=dba_data_temp$masks$Consensus
+            )
+        )
+    )
+    print("Temporary DBA object made of only consensus peaks")
+    print(dba_data_temp)
+    print(str(dba_data_temp))
+
+    consensus_peaks <- do.call(
+        dba.peakset,
+        append(
+            dba_peakset_default_params,
+            list(
+                DBA=dba_data_temp,
+                minOverlap=1,                                             # force it to 1 to get the union of peaks from each of the groups
+                bRetrieve=TRUE
+            )
+        )
+    )
+    print(paste("Found", nrow(consensus_peaks), "consensus peaks"))
+    if(nrow(consensus_peaks) == 0){
+        print("Found 0 consensus peaks. Exiting.")
+        quit(save = "no", status = 1, runLast = FALSE)
+    }
+    print(head(consensus_peaks))
+
+    dba_data <- do.call(
+        dba.count,
+        append(
+            dba_count_default_params,
+            list(
+                minOverlap=1,                                             # force it to 1 to get the union of peaks from each of the groups
+                peaks=consensus_peaks
+            )
+        )
+    )
+    export_corr_heatmap(                                                  # how it is calculated https://support.bioconductor.org/p/63034/
+        data=dba_data,
+        plot_title=paste0(
+            "Datasets correlation (",
+            ifelse(args$summits >= 0, paste0(args$summits, "bp rec. "), ""),
+            "cons. peaks)"
+        ),
+        rootname=paste(
+            args$output, "cns_pk_scr_corr", sep="_"
+        ),
+        pdf=args$pdf
+    )
+} else {
+    print(
+        paste(
+            "Searching for the consensus peaks with minimum peakset overlap",
+            args$minoverlap, "applied to all datasets jointly"
+        )
+    )
+    dba_data <- do.call(
+        dba.count,
+        append(
+            dba_count_default_params,
+            list(
+                minOverlap=args$minoverlap                                # to force using user-provided value
+            )
+        )
+    )
+    export_corr_heatmap(                                                  # how it is calculated https://support.bioconductor.org/p/63034/
+        data=dba_data,
+        plot_title=paste0(
+            "Datasets correlation (",
+            ifelse(args$summits >= 0, paste0(args$summits, "bp rec. "), ""),
+            "cons. peaks)"
+        ),
+        rootname=paste(
+            args$output, "cns_pk_scr_corr", sep="_"
+        ),
+        pdf=args$pdf
+    )
+}
+print(
+    paste0(
+        "This DBA object includes peaks with ",
+        "minOverlap=", args$minoverlap,
+        " applied either to all or grouped datasets"
+    )
+)
+print(dba_data)
+print(str(dba_data))
+
+export_corr_heatmap(
+    data=dba_data,
+    score=DBA_SCORE_READS,
+    plot_title="Datasets correlation (raw reads)",
+    rootname=paste(
+        args$output, "rw_rds_corr", sep="_"
+    ),
+    pdf=args$pdf
+)
+
+print("Defining correct base levels to reorder DBA metadata")
+correct_base_levels <- list()
+for (i in 1:length(colnames(metadata$raw))){
+    current_column <- colnames(metadata$raw)[i]
+    current_levels <- levels(metadata$raw[[current_column]])
+    correct_base_levels[[current_column]] <- current_levels[1]
+}
+print(correct_base_levels)
+
+print("Reordering DBA metadata levels")
+dba_data <- dba.contrast(                                # we need it only to make DBA object include correct metadata
+    dba_data,                                            # otherwise it will use some default order which we can't reproduce
+    design=args$design,
+    reorderMeta=correct_base_levels
+)
+print("This is DBA object with reordered metadata levels")
+print(dba_data)
+print(str(dba_data))
+
+print("Defining the contrast")
+if(is.null(args$contrast)){
+    print(
+        paste(
+            "Contrast is not provided. The last term",
+            "from the design formula will be used."
+        )
+    )
+    available_contrasts <- dba.contrast(
+        dba_data,
+        design=args$design,
+        bGetCoefficients=TRUE
+    )
+    print("Available contrasts")
+    print(available_contrasts)
+    selected_contrast <- available_contrasts[length(available_contrasts)]
+    print("Selected contrast")
+    print(selected_contrast)
+} else {
+    print("Using user-provided contrast")
+    selected_contrast <- get_contrast(
+        design_formula=as.formula(args$design),
+        metadata=metadata$raw,
+        args=args
+    )
+}
+
+dba_data <- dba.contrast(
+    dba_data,
+    design=args$design,                           # just in case set it here as well
+    contrast=selected_contrast
+)
+print("This is DBA object after we added contrast")
+print(dba_data)
+print(str(dba_data))
+
+print("Normalizing counts")
+dba_data <- dba.normalize(                        # this doesn't know anything about design formula yet, so it's not take into account when normalizing
+    dba_data,                                     # normalization somehow updates Score column from peaks?
+    method=args$method,
+    normalize=args$norm
+)
+print("This is DBA object after we normalized counts")
+print(dba_data)
+print(str(dba_data))
+
+export_corr_heatmap(
+    data=dba_data,
+    score=DBA_SCORE_NORMALIZED,
+    plot_title="Datasets correlation (norm. reads)",
+    rootname=paste(
+        args$output, "nr_rds_corr", sep="_"
+    ),
+    pdf=args$pdf
+)
+
+print("Performing the differential analysis")
+dba_data <- dba.analyze(
+    dba_data,
+    method=args$method,
+    bParallel=TRUE,
+    bReduceObjects=FALSE                             # we want to have a complete DESeq2 or edgeR object
+)
+print("This is DBA object after we performed differential analysis")
+print(dba_data)
+print(str(dba_data))
+
+norm_counts_data <- dba.report(
+    dba_data,
+    method=args$method,
+    th=1,                                            # to include all differentially bound sites
+    DataType=DBA_DATA_FRAME,
+    bCalled=FALSE,
+    bCounts=TRUE,
+    bNormalized=TRUE
+) %>% drop_na() %>%
+      filter_all(all_vars(!is.infinite(.))) %>%
+      mutate(feature=paste(Chr, paste(Start, End, sep="-"), sep=":")) %>%
+      dplyr::rename("log2FoldChange"="Fold") %>%
+      dplyr::rename("padj"="FDR") %>%
+      dplyr::rename("baseMean"="Conc") %>%
+      dplyr::rename("pvalue"="p-value") %>%
+      remove_rownames() %>% column_to_rownames("feature")
+print(head(norm_counts_data))
+
+export_plots(norm_counts_data, metadata$raw, args)
+
+print("Exporting differential binding sites")
+export_data(
+    norm_counts_data,                                                          # this is not filtered differentially expressed features
+    location=paste(args$output, "diff_sts.tsv", sep="_"),
+    digits=5
+)
+
+row_metadata <- norm_counts_data %>%
+                select(log2FoldChange, padj) %>%
+                filter(.$padj <= args$padj) %>%
+                arrange(desc(log2FoldChange))
+col_metadata <- metadata$raw %>%
+                mutate_at(colnames(.), as.vector)                              # need to convert to vector, because in our metadata everything was a factor
+
+print(
+    paste(
+        "Filtering normalized read counts matrix to include",
+        "only differential binding sites with padj <= ", args$padj
+    )
+)
+norm_counts_mat <- as.matrix(norm_counts_data[as.vector(rownames(row_metadata)), rownames(col_metadata)])
+print("Size of the normalized read counts matrix after filtering")
+print(dim(norm_counts_mat))
+print(head(norm_counts_mat))
+
+if (!is.null(args$cluster)){
+    if (args$cluster == "column" || args$cluster == "both") {
+        print("Clustering filtered read counts by columns")
+        clustered_data = get_clustered_data(
+            data=norm_counts_mat,
+            center=NULL,                                              # centering doesn't influence on the samples order
+            dist=args$columndist,
+            transpose=TRUE
+        )
+        col_metadata <- cbind(col_metadata, clustered_data$clusters)  # adding cluster labels
+        col_metadata <- col_metadata[clustered_data$order, ]          # reordering samples order based on the HOPACH clustering resutls
+        print("Reordered samples")
+        print(col_metadata)
+    }
+    if (args$cluster == "row" || args$cluster == "both") {
+        print("Clustering filtered normalized read counts by rows")
+        clustered_data = get_clustered_data(
+            data=norm_counts_mat,
+            center=if(args$center) "mean" else NULL,                  # about centering normalized data https://www.biostars.org/p/387863/
+            dist=args$rowdist,
+            transpose=FALSE
+        )
+        norm_counts_mat <- clustered_data$counts                      # can be different because of centering by rows mean
+        row_metadata <- cbind(row_metadata, clustered_data$clusters)  # adding cluster labels
+        row_metadata <- row_metadata[clustered_data$order, ]          # reordering features order based on the HOPACH clustering results
+        print("Reordered features")
+        print(head(row_metadata))
+    }
+}
+
+selected_sites <- makeGRangesFromDataFrame(
+    row_metadata %>%
+        mutate(rank=row_number()) %>%                                 # we use rank to maintain the  proper order of peaks
+        mutate(ranges=rownames(.)) %>%                                # need to save rownames, if we remove them profileplyr and dba.plotProfile messes up peaks order
+        separate(
+            col="ranges",
+            into=c("chr", "start", "end"),
+            sep=paste0(":", "|", "-")
+    ),
+    keep.extra.columns=TRUE                                           # to keep all metadata columns
+)
+
+split_by <- NULL
+if ("HCL" %in% colnames(row_metadata)){
+    split_by <- "HCL"
+} else if ("HCL.1" %in% colnames(row_metadata)){
+    split_by <- "HCL.1"
+}
+
+if(!is.null(split_by)){
+    print(paste("Splitting selected sites for profile heatmap by", split_by))
+    selected_sites <- split(
+        selected_sites,
+        fct_inorder(as.vector(as.character(mcols(selected_sites)[[split_by]])))            # reorder levels by first appearance in a vector - gives the proper cluster order
+    )
+} else {
+    print("Splitting selected sites for profile heatmap by log2FoldChange")
+    selected_sites <- GRangesList(
+        gain=selected_sites[selected_sites$log2FoldChange >= 0, ],
+        loss=selected_sites[selected_sites$log2FoldChange < 0, ]
+    )
+}
+
+print(head(selected_sites))
+
+selected_samples <- list()                                                                 # correct order of sample based on col_metadata
+for (i in 1:length(rownames(col_metadata))) {
+    current_sample <- rownames(col_metadata)[i]
+    selected_samples[[current_sample]] <- which(
+        as.vector(as.character(metadata$dba$SampleID)) == current_sample
+    )
+}
+print(head(selected_samples))
+
+export_profile_heatmap(
+    data=dba_data,
+    sites=selected_sites,
+    decreasing=FALSE,                                                                      # rank is a row number so we want to sort in increasing order
+    samples=selected_samples,
+    max_sites=Inf,                                                                         # to show all binding sites
+    split_by=split_by,                                                                     # we need it only to reorder Binging sites if selected_sites split by cluster
+    rootname=paste(args$output, "pk_prfl", sep="_"),
+    width=ifelse(length(args$aliases) > 5, length(args$aliases) * 150, 800),
+    pdf=args$pdf
+)
+
+# we do not reorder norm_counts_mat based on the clustering order
+# because when exporting it to GCT we use row_metadata and col_metadata
+# to force the proper order of rows and columns
+print("Exporting normalized read counts to GCT format")
+export_gct(
+    counts_mat=norm_counts_mat,
+    row_metadata=row_metadata,                                        # includes features as row names
+    col_metadata=col_metadata,                                        # includes samples as row names
+    location=paste(args$output, "nr_rds.gct", sep="_")
+)

--- a/tools/diffbind-for-spikein.cwl
+++ b/tools/diffbind-for-spikein.cwl
@@ -1,0 +1,882 @@
+cwlVersion: v1.0
+class: CommandLineTool
+
+
+requirements:
+- class: DockerRequirement
+  dockerPull: robertplayer/scidap-diffbind:v1.0.0
+
+
+inputs:
+
+  read_files_cond_1:
+    type: File[]
+    inputBinding:
+      prefix: "-r1"
+    doc: "Read files for condition 1. Minimim 2 files in BAM format"
+
+  read_files_cond_2:
+    type: File[]
+    inputBinding:
+      prefix: "-r2"
+    doc: "Read files for condition 2. Minimim 2 files in BAM format"
+
+  spikein_read_files_cond_1:
+    type: File[]
+    inputBinding:
+      prefix: "-s1"
+    doc: "Spike-in read files for condition 1. Minimim 2 files in BAM format"
+
+  spikein_read_files_cond_2:
+    type: File[]
+    inputBinding:
+      prefix: "-s2"
+    doc: "Spike-in read files for condition 2. Minimim 2 files in BAM format"
+
+  peak_files_cond_1:
+    type: File[]
+    inputBinding:
+      prefix: "-p1"
+    doc: "Peak files for condition 1. Minimim 2 files in format set with -pf"
+
+  peak_files_cond_2:
+    type: File[]
+    inputBinding:
+      prefix: "-p2"
+    doc: "Peak files for condition 2. Minimim 2 files in format set with -pf"
+
+  sample_names_cond_1:
+    type:
+      - "null"
+      - string[]
+    inputBinding:
+      prefix: "-n1"
+    doc: "Sample names for condition 1. Default: basenames of -r1 without extensions"
+
+  sample_names_cond_2:
+    type:
+      - "null"
+      - string[]
+    inputBinding:
+      prefix: "-n2"
+    doc: "Sample names for condition 2. Default: basenames of -r2 without extensions"
+
+  blocked_attributes:
+    type:
+      - "null"
+      - string[]
+    inputBinding:
+      prefix: "-bl"
+    doc: |
+      Blocking attribute for multi-factor analysis. Minimum 2.
+      Either names from --name1 or/and --name2 or array of strings that can be parsed by R to bool.
+      In the later case the order and size should correspond to [--read1]+[--read2].
+      Default: not applied
+
+  blocked_file:
+    type: File?
+    inputBinding:
+      prefix: "-bf"
+    doc: |
+      Blocking attribute metadata file for multi-factor analysis. Headerless TSV/CSV file.
+      First column - names from --name1 and --name2, second column - group name. --block is ignored
+
+  peakformat:
+    type:
+      - "null"
+      - type: enum
+        name: "peakformat"
+        symbols: ["raw","bed","narrow","macs","bayes","tpic","sicer","fp4","swembl","csv","report"]
+    inputBinding:
+      prefix: "-pf"
+    doc: "Peak files format. One of [raw, bed, narrow, macs, bayes, tpic, sicer, fp4, swembl, csv, report]. Default: macs"
+
+  name_cond_1:
+    type: string?
+    inputBinding:
+      prefix: "-c1"
+    doc: "Condition 1 name, single word with letters and numbers only. Default: condition_1"
+
+  name_cond_2:
+    type: string?
+    inputBinding:
+      prefix: "-c2"
+    doc: "Condition 2 name, single word with letters and numbers only. Default: condition_2"
+
+  cutoff_value:
+    type: float?
+    inputBinding:
+      prefix: "-cu"
+    doc: "P-value or FDR cutoff for reported results. Default: 0.05"
+
+  cutoff_param:
+    type:
+      - "null"
+      - type: enum
+        name: "cutoff"
+        symbols: ["pvalue", "fdr"]
+    inputBinding:
+      prefix: "-cp"
+    doc: "Parameter to which cutoff should be applied (fdr or pvalue). Default: fdr"
+
+  analysis_method:
+    type:
+      - "null"
+      - type: enum
+        name: "method"
+        symbols: ["deseq2", "edger", "all"]
+    inputBinding:
+      prefix: "-me"
+    doc: "Method by which to analyze differential binding affinity. Default: all"
+
+  min_overlap:
+    type: int?
+    inputBinding:
+      prefix: "-mo"
+    doc: "Min peakset overlap. Only include peaks in at least this many peaksets when generating consensus peakset. Default: 2"
+
+  rec_summits:
+    type: int?
+    inputBinding:
+      prefix: "--summits"
+    doc: |
+      Width in bp to extend peaks around their summits in both directions
+      and replace the original ones. Set it to 100 bp for ATAC-Seq and 200
+      bp for ChIP-Seq datasets. To skip peaks extension and replacement, set
+      it to negative value. Default: 200 bp (results in 401 bp wide peaks)
+
+  use_common:
+    type: boolean?
+    inputBinding:
+      prefix: "-uc"
+    doc: "Derive consensus peaks only from the common peaks within each condition. Min peakset overlap is ignored. Default: false"
+
+  output_prefix:
+    type: string?
+    inputBinding:
+      prefix: "--output"
+    doc: "Output prefix. Default: diffbind"
+
+  threads:
+    type: int?
+    inputBinding:
+      prefix: "-th"
+    doc: "Threads number. Default: 1"
+
+
+outputs:
+
+  diff_filtered_report_deseq:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_report_deseq.tsv"
+    doc: "Differential binding analysis report for significantly differentially bound sites exported as TSV, DESeq2"
+
+  diff_filtered_report_deseq_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_report_deseq_block.tsv"
+    doc: "Differential binding analysis report for significantly differentially bound sites exported as TSV, DESeq2 Blocked"
+
+  diff_filtered_report_edger:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_report_edger.tsv"
+    doc: "Differential binding analysis report for significantly differentially bound sites exported as TSV, EdgeR"
+
+  diff_filtered_report_edger_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_report_edger_block.tsv"
+    doc: "Differential binding analysis report for significantly differentially bound sites exported as TSV, EdgeR Blocked"
+
+  all_report_deseq:
+    type: File?
+    outputBinding:
+      glob: "*_all_report_deseq.tsv"
+    doc: "Not filtered differential binding analysis report exported as TSV, DESeq2"
+
+  all_report_deseq_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_all_report_deseq_block.tsv"
+    doc: "Not filtered differential binding analysis report exported as TSV, DESeq2 Blocked"
+
+  all_report_edger:
+    type: File?
+    outputBinding:
+      glob: "*_all_report_edger.tsv"
+    doc: "Not filtered differential binding analysis report exported as TSV, EdgeR"
+
+  all_report_edger_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_all_report_edger_block.tsv"
+    doc: "Not filtered differential binding analysis report exported as TSV, EdgeR Blocked"
+
+  boxplot_deseq:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_box_plot_deseq.png"
+    doc: "Box plots of read distributions for significantly differentially bound sites, DESeq2"
+
+  boxplot_deseq_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_box_plot_deseq.pdf"
+    doc: "Box plots of read distributions for significantly differentially bound sites, DESeq2"
+
+  boxplot_deseq_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_box_plot_deseq_block.png"
+    doc: "Box plots of read distributions for significantly differentially bound sites, DESeq2 Blocked"
+
+  boxplot_deseq_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_box_plot_deseq_block.pdf"
+    doc: "Box plots of read distributions for significantly differentially bound sites, DESeq2 Blocked"
+
+  boxplot_edger:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_box_plot_edger.png"
+    doc: "Box plots of read distributions for significantly differentially bound sites, EdgeR"
+  
+  boxplot_edger_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_box_plot_edger.pdf"
+    doc: "Box plots of read distributions for significantly differentially bound sites, EdgeR"
+
+  boxplot_edger_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_box_plot_edger_block.png"
+    doc: "Box plots of read distributions for significantly differentially bound sites, EdgeR Blocked"
+
+  boxplot_edger_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_box_plot_edger_block.pdf"
+    doc: "Box plots of read distributions for significantly differentially bound sites, EdgeR Blocked"
+
+  volcano_plot_deseq:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_volcano_plot_deseq.png"
+    doc: "Volcano plot for significantly differentially bound sites, DESeq2"
+
+  volcano_plot_deseq_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_volcano_plot_deseq.pdf"
+    doc: "Volcano plot for significantly differentially bound sites, DESeq2"
+
+  volcano_plot_deseq_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_volcano_plot_deseq_block.png"
+    doc: "Volcano plot for for significantly differentially bound sites, DESeq2 Blocked"
+
+  volcano_plot_deseq_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_volcano_plot_deseq_block.pdf"
+    doc: "Volcano plot for for significantly differentially bound sites, DESeq2 Blocked"
+
+  volcano_plot_edger:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_volcano_plot_edger.png"
+    doc: "Volcano plot for for significantly differentially bound sites, EdgeR"
+
+  volcano_plot_edger_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_volcano_plot_edger.pdf"
+    doc: "Volcano plot for for significantly differentially bound sites, EdgeR"
+
+  volcano_plot_edger_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_volcano_plot_edger_block.png"
+    doc: "Volcano plot for for significantly differentially bound sites, EdgeR Blocked"
+
+  volcano_plot_edger_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_volcano_plot_edger_block.pdf"
+    doc: "Volcano plot for for significantly differentially bound sites, EdgeR Blocked"
+
+  ma_plot_deseq:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_ma_plot_deseq.png"
+    doc: "MA plot for significantly differentially bound sites, DESeq2"
+
+  ma_plot_deseq_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_ma_plot_deseq.pdf"
+    doc: "MA plot for significantly differentially bound sites, DESeq2"
+
+  ma_plot_deseq_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_ma_plot_deseq_block.png"
+    doc: "MA plot for significantly differentially bound sites, DESeq2 Blocked"
+
+  ma_plot_deseq_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_ma_plot_deseq_block.pdf"
+    doc: "MA plot for significantly differentially bound sites, DESeq2 Blocked"
+
+  ma_plot_edger:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_ma_plot_edger.png"
+    doc: "MA plot for significantly differentially bound sites, EdgeR"
+
+  ma_plot_edger_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_ma_plot_edger.pdf"
+    doc: "MA plot for significantly differentially bound sites, EdgeR"
+    
+  ma_plot_edger_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_ma_plot_edger_block.png"
+    doc: "MA plot for significantly differentially bound sites, EdgeR Blocked"
+
+  ma_plot_edger_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_ma_plot_edger_block.pdf"
+    doc: "MA plot for significantly differentially bound sites, EdgeR Blocked"
+
+  diff_filtered_pca_plot_deseq:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_pca_plot_deseq.png"
+    doc: "PCA plot for significantly differentially bound sites, DESeq2"
+
+  diff_filtered_pca_plot_deseq_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_pca_plot_deseq.pdf"
+    doc: "PCA plot for significantly differentially bound sites, DESeq2"
+
+  diff_filtered_pca_plot_deseq_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_pca_plot_deseq_block.png"
+    doc: "PCA plot for significantly differentially bound sites, DESeq2 Blocked"
+  
+  diff_filtered_pca_plot_deseq_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_pca_plot_deseq_block.pdf"
+    doc: "PCA plot for significantly differentially bound sites, DESeq2 Blocked"
+
+  diff_filtered_pca_plot_edger:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_pca_plot_edger.png"
+    doc: "PCA plot for significantly differentially bound sites, EdgeR"
+
+  diff_filtered_pca_plot_edger_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_pca_plot_edger.pdf"
+    doc: "PCA plot for significantly differentially bound sites, EdgeR"
+
+  diff_filtered_pca_plot_edger_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_pca_plot_edger_block.png"
+    doc: "PCA plot for significantly differentially bound sites, EdgeR Blocked"
+
+  diff_filtered_pca_plot_edger_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_pca_plot_edger_block.pdf"
+    doc: "PCA plot for significantly differentially bound sites, EdgeR Blocked"
+
+  all_pca_plot_deseq:
+    type: File?
+    outputBinding:
+      glob: "*_all_pca_plot_deseq.png"
+    doc: "PCA plot for not filtered bound sites, DESeq2"
+
+  all_pca_plot_deseq_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_all_pca_plot_deseq.pdf"
+    doc: "PCA plot for not filtered bound sites, DESeq2"
+
+  all_pca_plot_deseq_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_all_pca_plot_deseq_block.png"
+    doc: "PCA plot for not filtered bound sites, DESeq2 Blocked"
+
+  all_pca_plot_deseq_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_all_pca_plot_deseq_block.pdf"
+    doc: "PCA plot for not filtered bound sites, DESeq2 Blocked"
+
+  all_pca_plot_edger:
+    type: File?
+    outputBinding:
+      glob: "*_all_pca_plot_edger.png"
+    doc: "PCA plot for not filtered bound sites, EdgeR"
+
+  all_pca_plot_edger_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_all_pca_plot_edger.pdf"
+    doc: "PCA plot for not filtered bound sites, EdgeR"
+
+  all_pca_plot_edger_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_all_pca_plot_edger_block.png"
+    doc: "PCA plot for not filtered bound sites, EdgeR Blocked"
+
+  all_pca_plot_edger_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_all_pca_plot_edger_block.pdf"
+    doc: "PCA plot for not filtered bound sites, EdgeR Blocked"
+
+  binding_heatmap_deseq:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_binding_heatmap_deseq.png"
+    doc: "Binding heatmap for significantly differentially bound sites, DESeq2"
+
+  binding_heatmap_deseq_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_binding_heatmap_deseq.pdf"
+    doc: "Binding heatmap for significantly differentially bound sites, DESeq2"
+
+  binding_heatmap_deseq_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_binding_heatmap_deseq_block.png"
+    doc: "Binding heatmap for significantly differentially bound sites, DESeq2 Blocked"
+
+  binding_heatmap_deseq_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_binding_heatmap_deseq_block.pdf"
+    doc: "Binding heatmap for significantly differentially bound sites, DESeq2 Blocked"
+
+  binding_heatmap_edger:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_binding_heatmap_edger.png"
+    doc: "Binding heatmap for significantly differentially bound sites, EdgeR"
+
+  binding_heatmap_edger_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_binding_heatmap_edger.pdf"
+    doc: "Binding heatmap for significantly differentially bound sites, EdgeR"
+
+  binding_heatmap_edger_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_binding_heatmap_edger_block.png"
+    doc: "Binding heatmap for significantly differentially bound sites, EdgeR Blocked"
+
+  binding_heatmap_edger_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_binding_heatmap_edger_block.pdf"
+    doc: "Binding heatmap for significantly differentially bound sites, EdgeR Blocked"
+
+  diff_filtered_norm_counts_corr_heatmap_deseq:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_normalized_counts_correlation_heatmap_deseq.png"
+    doc: "Normalized counts correlation heatmap for significantly differentially bound sites, DESeq2"
+
+  diff_filtered_norm_counts_corr_heatmap_deseq_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_normalized_counts_correlation_heatmap_deseq.pdf"
+    doc: "Normalized counts correlation heatmap for significantly differentially bound sites, DESeq2"
+
+  diff_filtered_norm_counts_corr_heatmap_deseq_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_normalized_counts_correlation_heatmap_deseq_block.png"
+    doc: "Normalized counts correlation heatmap for significantly differentially bound sites, DESeq2 Blocked"
+
+  diff_filtered_norm_counts_corr_heatmap_deseq_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_normalized_counts_correlation_heatmap_deseq_block.pdf"
+    doc: "Normalized counts correlation heatmap for significantly differentially bound sites, DESeq2 Blocked"
+
+  diff_filtered_norm_counts_corr_heatmap_edger:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_normalized_counts_correlation_heatmap_edger.png"
+    doc: "Normalized counts correlation heatmap for significantly differentially bound sites, EdgeR"
+
+  diff_filtered_norm_counts_corr_heatmap_edger_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_normalized_counts_correlation_heatmap_edger.pdf"
+    doc: "Normalized counts correlation heatmap for significantly differentially bound sites, EdgeR"
+
+  diff_filtered_norm_counts_corr_heatmap_edger_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_normalized_counts_correlation_heatmap_edger_block.png"
+    doc: "Normalized counts correlation heatmap for significantly differentially bound sites, EdgeR Blocked"
+
+  diff_filtered_norm_counts_corr_heatmap_edger_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_filtered_normalized_counts_correlation_heatmap_edger_block.pdf"
+    doc: "Normalized counts correlation heatmap for significantly differentially bound sites, EdgeR Blocked"
+
+  all_norm_counts_corr_heatmap_deseq:
+    type: File?
+    outputBinding:
+      glob: "*_all_normalized_counts_correlation_heatmap_deseq.png"
+    doc: "Not filtered normalized counts correlation heatmap, DESeq2"
+
+  all_norm_counts_corr_heatmap_deseq_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_all_normalized_counts_correlation_heatmap_deseq.pdf"
+    doc: "Not filtered normalized counts correlation heatmap, DESeq2"
+
+  all_norm_counts_corr_heatmap_deseq_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_all_normalized_counts_correlation_heatmap_deseq_block.png"
+    doc: "Not filtered normalized counts correlation heatmap, DESeq2 Blocked"
+
+  all_norm_counts_corr_heatmap_deseq_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_all_normalized_counts_correlation_heatmap_deseq_block.pdf"
+    doc: "Not filtered normalized counts correlation heatmap, DESeq2 Blocked"
+
+  all_norm_counts_corr_heatmap_edger:
+    type: File?
+    outputBinding:
+      glob: "*_all_normalized_counts_correlation_heatmap_edger.png"
+    doc: "Not filtered normalized counts correlation heatmap, EdgeR"
+
+  all_norm_counts_corr_heatmap_edger_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_all_normalized_counts_correlation_heatmap_edger.pdf"
+    doc: "Not filtered normalized counts correlation heatmap, EdgeR"
+
+  all_norm_counts_corr_heatmap_edger_blocked:
+    type: File?
+    outputBinding:
+      glob: "*_all_normalized_counts_correlation_heatmap_edger_block.png"
+    doc: "Not filtered normalized counts correlation heatmap, EdgeR Blocked"
+
+  all_norm_counts_corr_heatmap_edger_blocked_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_all_normalized_counts_correlation_heatmap_edger_block.pdf"
+    doc: "Not filtered normalized counts correlation heatmap, EdgeR Blocked"
+
+  consensus_peak_venn_diagram:
+    type: File?
+    outputBinding:
+      glob: "*_consensus_peak_venn_diagram.png"
+    doc: "Consensus peak Venn Diagram" 
+
+  consensus_peak_venn_diagram_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_consensus_peak_venn_diagram.pdf"
+    doc: "Consensus peak Venn Diagram" 
+
+  raw_counts_corr_heatmap:
+    type: File?
+    outputBinding:
+      glob: "*_raw_counts_correlation_heatmap.png"
+    doc: "Raw counts correlation heatmap"
+
+  raw_counts_corr_heatmap_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_raw_counts_correlation_heatmap.pdf"
+    doc: "Raw counts correlation heatmap"
+
+  peak_overlap_corr_heatmap:
+    type: File?
+    outputBinding:
+      glob: "*_peak_overlap_correlation_heatmap.png"
+    doc: "Peak overlap correlation heatmap"
+
+  peak_overlap_corr_heatmap_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_peak_overlap_correlation_heatmap.pdf"
+    doc: "Peak overlap correlation heatmap"
+
+  peak_overlap_rate_plot_cond_1:
+    type: File?
+    outputBinding:
+      glob: "*_condition_1_peak_overlap_rate.png"
+    doc: "Peak overlap rate plot, condition 1"
+
+  peak_overlap_rate_plot_cond_1_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_condition_1_peak_overlap_rate.pdf"
+    doc: "Peak overlap rate plot, condition 1"
+
+  peak_overlap_rate_plot_cond_2:
+    type: File?
+    outputBinding:
+      glob: "*_condition_2_peak_overlap_rate.png"
+    doc: "Peak overlap rate plot, condition 2"
+
+  peak_overlap_rate_plot_cond_2_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_condition_2_peak_overlap_rate.pdf"
+    doc: "Peak overlap rate plot, condition 2"
+
+  all_peak_overlap_rate_plot:
+    type: File?
+    outputBinding:
+      glob: "*_all_peak_overlap_rate.png"
+    doc: "All peak overlap rate plot"
+
+  all_peak_overlap_rate_plot_pdf:
+    type: File?
+    outputBinding:
+      glob: "*_all_peak_overlap_rate.pdf"
+    doc: "All peak overlap rate plot"
+
+  stdout_log:
+    type: stdout
+
+  stderr_log:
+    type: stderr
+
+
+baseCommand: ["run_diffbind-for-spikein.R"]
+stdout: diffbind_stdout.log
+stderr: diffbind_stderr.log
+
+
+$namespaces:
+  s: http://schema.org/
+
+$schemas:
+- https://github.com/schemaorg/schemaorg/raw/main/data/releases/11.01/schemaorg-current-http.rdf
+
+label: "DiffBind spike-in - Differential Binding Analysis of Peak Data"
+s:name: "DiffBind spike-in - Differential Binding Analysis of Peak Data"
+s:alternateName: "Compute differentially bound sites from multiple ChIP-seq spike-in experiments using affinity (quantitative) data."
+
+s:downloadUrl: https://raw.githubusercontent.com/Barski-lab/workflows/master/tools/diffbind.cwl
+s:codeRepository: https://github.com/Barski-lab/workflows
+s:license: http://www.apache.org/licenses/LICENSE-2.0
+
+s:isPartOf:
+  class: s:CreativeWork
+  s:name: Common Workflow Language
+  s:url: http://commonwl.org/
+
+s:creator:
+- class: s:Organization
+  s:legalName: "Cincinnati Children's Hospital Medical Center"
+  s:location:
+  - class: s:PostalAddress
+    s:addressCountry: "USA"
+    s:addressLocality: "Cincinnati"
+    s:addressRegion: "OH"
+    s:postalCode: "45229"
+    s:streetAddress: "3333 Burnet Ave"
+    s:telephone: "+1(513)636-4200"
+  s:logo: "https://www.cincinnatichildrens.org/-/media/cincinnati%20childrens/global%20shared/childrens-logo-new.png"
+  s:department:
+  - class: s:Organization
+    s:legalName: "Allergy and Immunology"
+    s:department:
+    - class: s:Organization
+      s:legalName: "Barski Research Lab"
+      s:member:
+      - class: s:Person
+        s:name: Michael Kotliar
+        s:email: mailto:misha.kotliar@gmail.com
+        s:sameAs:
+        - id: http://orcid.org/0000-0002-6486-3898
+
+doc: |
+  Runs R script to compute differentially bound sites from multiple ChIP-seq spike-in experiments using affinity (quantitative) and occupancy data.
+
+  Selected excerpts on Normalization from diffbind manual (https://bioconductor.org/packages/release/bioc/vignettes/DiffBind/inst/doc/DiffBind.pdf):
+
+    A third method is also provided that avoids making any assumptions regarding the distribution
+    of reads between binding sites in different samples that may be specific to RNA-seq analysis
+    and inappropriate for ChIP-seq analysis. This method ("lib" or DBA_NORM_LIB) is based on
+    the different library sizes for each sample, computing normalization factors to weight each
+    sample so as to appear to have the same library size. For DESeq2 , this is accomplished
+    by dividing the number of reads in each library by the mean library size. For edgeR , the
+    normalization factors are all set to 1.0, indicating that only library-size normalization should
+    occur.
+
+    ...
+
+    In the previous section, we saw how a library-size normalization based on the full library
+    size, rather than on the reads in the enriched areas designated by the consensus peaks set,
+    enabled an analysis that avoided making assumption about the changes in binding patterns
+    (specifically, assumptions that binding changes are roughly balanced). Another way to do this,
+    while gaining some of the benefits of the native normalization methods, is to use background
+    normalization. Given the difficulty in differentiating between technical biases and biological
+    signal when attempting to normalize ChIP-seq data, the idea is to normalize based on a more
+    neutral sample of reads.
+
+    The core background normalization technique is to divide the genome into large bins and
+    count overlapping reads. As the enrichment expected in ChIP-seq (and ATAC-seq) is expected to
+    occur over relatively narrow intervals (roughly between 100bp and 600bp), it is
+    expected that there should not be systematic differences in signals over much larger intervals
+    (on the order of 10,000bp and greater). Any differences seen should be technical rather than
+    biological, so it is safer to normalize based these differences.
+
+    Note also that this type of background normalization is one of the methods recommended
+    for ATAC-seq analysis.
+
+    By specifying background=TRUE in dba.normalize, all chromosomes that contains peaks in the
+    consensus set are divided into non-overlapping bins (default size 15,000bp) and overlapping
+    reads counted. These can then be normalized using any of the normalization methods. While
+    generally doing a library size based normalization will yield the same result as on the full library
+    size, the native normalization methods can be applied to the background bins.
+
+    ...
+
+    An alternative for avoiding the use of the consensus count matrix
+            (A matrix of offsets can be supplied via the dba.normalize function,
+             or an offset matrix can be calculated using a loess fit)
+                                                                      when normalizing ChIP-seq
+    data is to use spike-in data, where exogenous chromatin (usually from Drosophila melanogaster)
+    is "spiked in" to the ChIP. If the amount of spiked-in chromatin can be precisely controlled,
+    then we can use the relative amounts of reads that map to the alternative reference genome
+    for each sample. Counting these reads then forms a background we can use
+    in the same manner as background normalization discussed previously (either a library size
+    adjustment using the total number of exogenous reads for each sample, or a native RNA-seq
+    method (TMM or RLE) taking into account how those reads are distributed).
+
+    And from one of the dev of diffbind, Rory Stark:
+
+        RLE is a good choice when you expect most of the peaks not to be different between the
+        conditions, which is exactly the assumption for spike-ins, where differences in the raw
+        data should be due to IP efficiency and sequencing depth.
+
+    So for this SciDAP workflow, we use 'spikes <- dba.normalize(spikes, normalize="RLE", background=TRUE)'
+
+
+s:about: |
+  usage: run_diffbind.R [-h] -r1 READ1 [READ1 ...] -r2 READ2 [READ2 ...] -p1
+                        PEAK1 [PEAK1 ...] -p2 PEAK2 [PEAK2 ...]
+                        [-n1 [NAME1 ...]] [-n2 [NAME2 ...]] [-bl [BLOCK ...]]
+                        [-bf BLOCKFILE]
+                        [-pf {raw,bed,narrow,macs,bayes,tpic,sicer,fp4,swembl,csv,report}]
+                        [-c1 CONDITION1] [-c2 CONDITION2]
+                        [-me {edger,deseq2,all}] [-mo MINOVERLAP] [-uc]
+                        [--summits SUMMITS] [-cu CUTOFF] [-cp {pvalue,fdr}]
+                        [-co {Reds,Greens,Blues,Greys,YlOrRd,Oranges}]
+                        [-th THREADS] [-pa PADDING] [-o OUTPUT]
+
+  Differential binding analysis of ChIP-Seq experiments using affinity (read
+  count) data
+
+  options:
+    -h, --help            show this help message and exit
+    -r1 READ1 [READ1 ...], --read1 READ1 [READ1 ...]
+                          Read files for condition 1. Minimim 2 files in BAM
+                          format
+    -r2 READ2 [READ2 ...], --read2 READ2 [READ2 ...]
+                          Read files for condition 2. Minimim 2 files in BAM
+                          format
+    -s1 SPIKE1 [SPIKE1 ...], --spike1 SPIKE1 [SPIKE1 ...]
+                          Spike-in read files for condition 1. Minimim 2 files
+                          in BAM format
+    -s2 SPIKE2 [SPIKE2 ...], --spike2 SPIKE2 [SPIKE2 ...]
+                          Spike-in read files for condition 2. Minimim 2 files
+                          in BAM format
+    -p1 PEAK1 [PEAK1 ...], --peak1 PEAK1 [PEAK1 ...]
+                          Peak files for condition 1. Minimim 2 files in format
+                          set with -pf
+    -p2 PEAK2 [PEAK2 ...], --peak2 PEAK2 [PEAK2 ...]
+                          Peak files for condition 2. Minimim 2 files in format
+                          set with -pf
+    -n1 [NAME1 ...], --name1 [NAME1 ...]
+                          Sample names for condition 1. Default: basenames of
+                          -r1 without extensions
+    -n2 [NAME2 ...], --name2 [NAME2 ...]
+                          Sample names for condition 2. Default: basenames of
+                          -r2 without extensions
+    -bl [BLOCK ...], --block [BLOCK ...]
+                          Blocking attribute for multi-factor analysis. Minimum
+                          2. Either names from --name1 or/and --name2 or array
+                          of bool based on [read1]+[read2]. Default: not applied
+    -bf BLOCKFILE, --blockfile BLOCKFILE
+                          Blocking attribute metadata file for multi-factor
+                          analysis. Headerless TSV/CSV file. First column -
+                          names from --name1 and --name2, second column - group
+                          name. --block is ignored
+    -pf {raw,bed,narrow,macs,bayes,tpic,sicer,fp4,swembl,csv,report}, --peakformat {raw,bed,narrow,macs,bayes,tpic,sicer,fp4,swembl,csv,report}
+                          Peak files format. One of [raw, bed, narrow, macs,
+                          bayes, tpic, sicer, fp4, swembl, csv, report].
+                          Default: macs
+    -c1 CONDITION1, --condition1 CONDITION1
+                          Condition 1 name, single word with letters and numbers
+                          only. Default: condition_1
+    -c2 CONDITION2, --condition2 CONDITION2
+                          Condition 2 name, single word with letters and numbers
+                          only. Default: condition_2
+    -me {edger,deseq2,all}, --method {edger,deseq2,all}
+                          Method by which to analyze differential binding
+                          affinity. Default: all
+    -mo MINOVERLAP, --minoverlap MINOVERLAP
+                          Min peakset overlap. Only include peaks in at least
+                          this many peaksets when generating consensus peakset.
+                          Default: 2
+    -uc, --usecommon      Derive consensus peaks only from the common peaks
+                          within each condition. Min peakset overlap and min
+                          read counts are ignored. Default: false
+    --summits SUMMITS     Width in bp to extend peaks around their summits in
+                          both directions and replace the original ones. Set it
+                          to 100 bp for ATAC-Seq and 200 bp for ChIP-Seq
+                          datasets. To skip peaks extension and replacement, set
+                          it to negative value. Default: 200 bp (results in 401
+                          bp wide peaks)
+    -cu CUTOFF, --cutoff CUTOFF
+                          Cutoff for reported results. Applied to the parameter
+                          set with -cp. Default: 0.05
+    -cp {pvalue,fdr}, --cparam {pvalue,fdr}
+                          Parameter to which cutoff should be applied (fdr or
+                          pvalue). Default: fdr
+    -co {Reds,Greens,Blues,Greys,YlOrRd,Oranges}, --color {Reds,Greens,Blues,Greys,YlOrRd,Oranges}
+                          Color scheme. Default: Greens
+    -th THREADS, --threads THREADS
+                          Threads to use
+    -pa PADDING, --padding PADDING
+                          Padding for generated heatmaps. Default: 20
+    -o OUTPUT, --output OUTPUT
+                          Output prefix. Default: diffbind

--- a/workflows/diffbind-for-spikein.cwl
+++ b/workflows/diffbind-for-spikein.cwl
@@ -1,0 +1,1522 @@
+cwlVersion: v1.0
+class: Workflow
+
+
+requirements:
+  - class: StepInputExpressionRequirement
+  - class: InlineJavascriptRequirement
+  - class: MultipleInputFeatureRequirement
+
+
+'sd:upstream':
+  first_biological_condition:
+    - "trim-chipseq-pe-spike.cwl"
+  second_biological_condition:
+    - "trim-chipseq-pe-spike.cwl"
+  blocked_condition:
+    - "cutandrun-macs2-pe.cwl"
+    - "cutandrun-seacr-pe.cwl"
+    - "trim-chipseq-se.cwl"
+    - "trim-chipseq-pe.cwl"
+    - "trim-chipseq-pe-spike.cwl"
+    - "trim-atacseq-se.cwl"
+    - "trim-atacseq-pe.cwl"
+  genome_indices:
+    - "genome-indices.cwl"
+
+inputs:
+
+  alias:
+    type: string
+    label: "Experiment short name/Alias"
+    sd:preview:
+      position: 1
+
+  read_files_cond_1:
+    type: File[]
+    format: "http://edamontology.org/format_2572"
+    label: "Biological condition 1 samples. Minimum 2 samples"
+    doc: "Read files for condition 1. Minimim 2 files in BAM format"
+    'sd:upstreamSource': "first_biological_condition/bambai_pair"
+    'sd:localLabel': true
+
+  read_files_cond_2:
+    type: File[]
+    format: "http://edamontology.org/format_2572"
+    label: "Biological condition 2 samples. Minimum 2 samples"
+    doc: "Read files for condition 2. Minimim 2 files in BAM format"
+    'sd:upstreamSource': "second_biological_condition/bambai_pair"
+    'sd:localLabel': true
+
+  spikein_read_files_cond_1:
+    type: File[]
+    format: "http://edamontology.org/format_2572"
+    label: "Biological condition 1 spike-in samples. Minimum 2 samples"
+    doc: "Spike-in read files for condition 1. Minimim 2 files in BAM format"
+    'sd:upstreamSource': "first_biological_condition/bambai_pair_spikein"
+
+  spikein_read_files_cond_2:
+    type: File[]
+    format: "http://edamontology.org/format_2572"
+    label: "Biological condition 2 spike-in samples. Minimum 2 samples"
+    doc: "Spike-in read files for condition 2. Minimim 2 files in BAM format"
+    'sd:upstreamSource': "second_biological_condition/bambai_pair_spikein"
+
+  peak_files_cond_1:
+    type: File[]
+    format: "http://edamontology.org/format_3468"
+    label: "Biological condition 1 samples. Minimum 2 samples"
+    doc: "XLS peak files for condition 1 from MACS2. Minimim 2 files. Order corresponds to read_files_cond_1"
+    'sd:upstreamSource': "first_biological_condition/macs2_called_peaks"
+
+  peak_files_cond_2:
+    type: File[]
+    format: "http://edamontology.org/format_3468"
+    label: "Biological condition 2 samples. Minimum 2 samples"
+    doc: "XLS peak files for condition 2 from MACS2. Minimim 2 files. Order corresponds to read_files_cond_2"
+    'sd:upstreamSource': "second_biological_condition/macs2_called_peaks"
+
+  genome_coverage_files_cond_1:
+    type: File[]
+    format: "http://edamontology.org/format_3006"
+    label: "Genome coverage(s) for biological condition 1"
+    doc: "Genome coverage bigWig file(s) for biological condition 1"
+    'sd:upstreamSource': "first_biological_condition/bigwig"
+
+  genome_coverage_files_cond_2:
+    type: File[]
+    format: "http://edamontology.org/format_3006"
+    label: "Genome coverage(s) for biological condition 2"
+    doc: "Genome coverage bigWig file(s) for biological condition 2"
+    'sd:upstreamSource': "second_biological_condition/bigwig"
+
+  narrow_peaks_files_cond_1:
+    type:
+      - "null"
+      - File[]
+    format: "http://edamontology.org/format_3613"
+    label: "Called peaks for biological condition 1"
+    doc: "Narrow peaks file(s) for biological condition 1"
+    'sd:upstreamSource': "first_biological_condition/macs2_narrow_peaks"
+
+  narrow_peaks_files_cond_2:
+    type:
+      - "null"
+      - File[]
+    format: "http://edamontology.org/format_3613"
+    label: "Called peaks for biological condition 2"
+    doc: "Narrow peaks file(s) for biological condition 2"
+    'sd:upstreamSource': "second_biological_condition/macs2_narrow_peaks"
+
+  broad_peaks_files_cond_1:
+    type:
+      - "null"
+      - File[]
+    format: "http://edamontology.org/format_3614"
+    label: "Called peaks for biological condition 1"
+    doc: "Broad peaks file(s) for biological condition 1"
+    'sd:upstreamSource': "first_biological_condition/macs2_broad_peaks"
+
+  broad_peaks_files_cond_2:
+    type:
+      - "null"
+      - File[]
+    format: "http://edamontology.org/format_3614"
+    label: "Called peaks for biological condition 2"
+    doc: "Broad peaks file(s) for biological condition 2"
+    'sd:upstreamSource': "second_biological_condition/macs2_broad_peaks"
+
+  name_cond_1:
+    type: string?
+    default: "condition_1"
+    label: "Condition 1 name, single word with letters and numbers only"
+    doc: "Condition 1 name, single word with letters and numbers only"
+    'sd:layout':
+      advanced: true
+
+  name_cond_2:
+    type: string?
+    default: "condition_2"
+    label: "Condition 2 name, single word with letters and numbers only"
+    doc: "Condition 2 name, single word with letters and numbers only"
+    'sd:layout':
+      advanced: true
+
+  sample_names_cond_1:
+    type:
+      - "null"
+      - string[]
+    label: "Biological condition 1 sample names"
+    doc: "Aliases for biological condition 1 samples to make the legend for generated plots. Order corresponds to the read_files_cond_1"
+    'sd:upstreamSource': "first_biological_condition/alias"
+
+  sample_names_cond_2:
+    type:
+      - "null"
+      - string[]
+    label: "Biological condition 2 sample names"
+    doc: "Aliases for biological condition 2 samples to make the legend for generated plots. Order corresponds to the read_files_cond_2"
+    'sd:upstreamSource': "second_biological_condition/alias"
+
+  blocked_attributes:
+    type:
+      - "null"
+      - string[]
+    default: null
+    label: "Blocking attributes for multi-factor analysis. Minimum 2"
+    doc: |
+      Blocking attributes for multi-factor analysis. Minimum 2.
+      Either names from --name1 or/and --name2 or array of strings that can be parsed by R to bool.
+      In the later case the order and size should correspond to [--read1]+[--read2].
+      Default: not applied
+    'sd:upstreamSource': "blocked_condition/alias"
+    'sd:localLabel': true
+
+  blocked_file:
+    type: File?
+    label: "Blocking attribute headerless TSV/CSV file for multi-factor analysis with columns to set name and group. If this inputs is set, blocking attributes above are ignored"
+    format: "http://edamontology.org/format_2330"
+    doc: |
+      Blocking attribute metadata file for multi-factor analysis. Headerless TSV/CSV file.
+      First column - names from --name1 and --name2, second column - group name. --block is ignored
+
+  annotation_file:
+    type: File
+    label: "Genome annotation"
+    format: "http://edamontology.org/format_3475"
+    doc: "Genome annotation file in TSV format"
+    'sd:upstreamSource': "genome_indices/annotation"
+
+  chrom_length_file:
+    type: File
+    format: "http://edamontology.org/format_2330"
+    label: "Chromosome length file"
+    doc: "Chromosome length file"
+    'sd:upstreamSource': "genome_indices/chrom_length"   
+
+  rec_summits:
+    type: int?
+    default: 200
+    label: "Width in bp to extend peaks around summits"
+    doc: |
+      Width in bp to extend peaks around their summits
+      in both directions and replace the original ones.
+      Set it to 100 bp for ATAC-Seq and 200 bp for
+      ChIP-Seq datasets. To skip peaks extension and
+      replacement, set it to negative value.
+      Default: 200 bp (results in 401 bp wide peaks)
+    'sd:layout':
+      advanced: true
+
+  promoter_dist:
+    type: int?
+    default: 1000
+    label: "Promoter distance, bp"
+    doc: "Max distance from gene TSS (in both direction) overlapping which the peak will be assigned to the promoter region. Default: 1000 bp"
+    'sd:layout':
+      advanced: true
+
+  upstream_dist:
+    type: int?
+    default: 20000
+    label: "Upstream distance, bp"
+    doc: "Max distance from the promoter (only in upstream direction) overlapping which the peak will be assigned to the upstream region. Default: 20,000 bp"
+    'sd:layout':
+      advanced: true
+
+  min_overlap:
+    type: int?
+    default: 2
+    label: "Minimum peakset overlap"
+    doc: "Min peakset overlap. Only include peaks in at least this many peaksets when generating consensus peakset. Default: 2"
+    'sd:layout':
+      advanced: true
+
+  use_common:
+    type: boolean?
+    default: false
+    label: "Use common peaks within each condition. Ignore Minimum peakset overlap"
+    doc: "Derive consensus peaks only from the common peaks within each condition. Min peakset overlap is ignored. Default: false"
+    'sd:layout':
+      advanced: true
+
+  cutoff_value:
+    type: float?
+    default: 0.05
+    label: "P-value or FDR cutoff for reported results"
+    doc: "P-value or FDR cutoff for reported results"
+    'sd:layout':
+      advanced: true
+
+  cutoff_param:
+    type:
+      - "null"
+      - type: enum
+        name: "cutoff"
+        symbols: ["pvalue", "fdr"]
+    default: "pvalue"
+    label: "Parameter to which cutoff should be applied"
+    doc: "Parameter to which cutoff should be applied (fdr or pvalue). Default: fdr"
+    'sd:layout':
+      advanced: true
+
+  analysis_method:
+    type:
+      - "null"
+      - type: enum
+        name: "method"
+        symbols: ["deseq2", "edger"]
+    default: "edger"
+    label: "Analysis method"
+    doc: "Method by which to analyze differential binding affinity. Default: deseq2"
+    'sd:layout':
+      advanced: true
+
+  threads:
+    type: int?
+    default: 4
+    label: "Number of threads"
+    doc: "Number of threads for those steps that support multithreading"
+    'sd:layout':
+      advanced: true
+
+
+outputs:
+
+  genome_coverage_cond_1:
+    type: File[]
+    format: "http://edamontology.org/format_3006"
+    label: "Genome coverage(s) for biological condition 1"
+    doc: "Genome coverage bigWig file(s) for biological condition 1"
+    outputSource: pipe/coverage_files_cond_1
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        type: 'wig'
+        name: "Condition 1 genome coverage"
+        height: 120
+
+  genome_coverage_cond_2:
+    type: File[]
+    format: "http://edamontology.org/format_3006"
+    label: "Genome coverage(s) for biological condition 2"
+    doc: "Genome coverage bigWig file(s) for biological condition 2"
+    outputSource: pipe/coverage_files_cond_2
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        type: 'wig'
+        name: "Condition 2 genome coverage"
+        height: 120
+
+  narrow_peaks_cond_1:
+    type:
+      - "null"
+      - File[]
+    format: "http://edamontology.org/format_3613"
+    label: "Called peaks for biological condition 1"
+    doc: "Narrow peaks file(s) for biological condition 1"
+    outputSource: pipe/n_peaks_files_cond_1
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        type: 'annotation'
+        name: "Condition 1 called peaks"
+        displayMode: "COLLAPSE"
+        height: 40
+
+  narrow_peaks_cond_2:
+    type:
+      - "null"
+      - File[]
+    format: "http://edamontology.org/format_3613"
+    label: "Called peaks for biological condition 2"
+    doc: "Narrow peaks file(s) for biological condition 2"
+    outputSource: pipe/n_peaks_files_cond_2
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        type: 'annotation'
+        name: "Condition 2 called peaks"
+        displayMode: "COLLAPSE"
+        height: 40
+
+  broad_peaks_cond_1:
+    type:
+      - "null"
+      - File[]
+    format: "http://edamontology.org/format_3614"
+    label: "Called peaks for biological condition 1"
+    doc: "Broad peaks file(s) for biological condition 1"
+    outputSource: pipe/b_peaks_files_cond_1
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        type: 'annotation'
+        name: "Condition 1 called peaks"
+        displayMode: "COLLAPSE"
+        height: 40
+
+  broad_peaks_cond_2:
+    type:
+      - "null"
+      - File[]
+    format: "http://edamontology.org/format_3614"
+    label: "Called peaks for biological condition 2"
+    doc: "Broad peaks file(s) for biological condition 2"
+    outputSource: pipe/b_peaks_files_cond_2
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        type: 'annotation'
+        name: "Condition 2 called peaks"
+        displayMode: "COLLAPSE"
+        height: 40
+
+  diffbind_report_file:
+    type: File
+    format: "http://edamontology.org/format_3475"
+    label: "Differential binding analysis results"
+    doc: "Differential binding analysis results exported as TSV"
+    outputSource: restore_columns/output_file
+    'sd:visualPlugins':
+      - syncfusiongrid:
+          tab: 'Differential Peak Calling'
+          Title: 'Differential Binding Analysis Results'
+
+  diffbind_report_file_formatted:
+    type: File
+    format: "http://edamontology.org/format_3475"
+    label: "Differential binding analysis results formatted as chip/atac/cutandrun results"
+    doc: "Differential binding analysis results  formatted as chip/atac/cutandrun results exported as TSV"
+    outputSource: iaintersect_result_formatted/output_file_1
+
+  iaintersect_result:
+    type: File
+    format: "http://edamontology.org/format_3475"
+    label: "Differential binding analysis results formatted as chip/atac/cutandrun results"
+    doc: "Differential binding analysis results  formatted as chip/atac/cutandrun results exported as TSV"
+    outputSource: iaintersect_result_formatted_for_setops/output_file_1
+
+  diffbind_bed_file:
+    type: File
+    format: "http://edamontology.org/format_3004"
+    label: "Estimated differential peaks"
+    doc: "Estimated differential peaks, bigBed"
+    outputSource: bed_to_bigbed/bigbed_file
+    'sd:visualPlugins':
+    - igvbrowser:
+        tab: 'IGV Genome Browser'
+        id: 'igvbrowser'
+        type: 'annotation'
+        format: 'bigbed'
+        name: "Differential peaks"
+        height: 40
+
+  diffbind_peak_correlation_heatmap:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "Peak overlap correlation heatmap"
+    doc: "Peak overlap correlation heatmap"
+    outputSource: diffbind/peak_overlap_corr_heatmap
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'Peak overlap correlation heatmap'
+
+  diffbind_peak_correlation_heatmap_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "Peak overlap correlation heatmap"
+    doc: "Peak overlap correlation heatmap"
+    outputSource: diffbind/peak_overlap_corr_heatmap_pdf
+
+  diffbind_counts_correlation_heatmap:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "Raw counts correlation heatmap"
+    doc: "Raw counts correlation heatmap"
+    outputSource: diffbind/raw_counts_corr_heatmap
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'Raw counts correlation heatmap'
+
+  diffbind_counts_correlation_heatmap_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "Raw counts correlation heatmap"
+    doc: "Raw counts correlation heatmap"
+    outputSource: diffbind/raw_counts_corr_heatmap_pdf
+
+  diffbind_consensus_peak_venn_diagram:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "Consensus peak Venn Diagram"
+    doc: "Consensus peak Venn Diagram"
+    outputSource: diffbind/consensus_peak_venn_diagram
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'Consensus peak Venn Diagram'
+
+  diffbind_consensus_peak_venn_diagram_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "Consensus peak Venn Diagram"
+    doc: "Consensus peak Venn Diagram"
+    outputSource: diffbind/consensus_peak_venn_diagram_pdf
+
+  diffbind_all_peak_overlap_rate_plot:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "All peak overlap rate plot"
+    doc: "All peak overlap rate plot"
+    outputSource: diffbind/all_peak_overlap_rate_plot
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'All peak overlap rate plot'  
+
+  diffbind_all_peak_overlap_rate_plot_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "All peak overlap rate plot"
+    doc: "All peak overlap rate plot"
+    outputSource: diffbind/all_peak_overlap_rate_plot_pdf
+
+  diffbind_peak_overlap_rate_plot_cond_1:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "Condition 1 peak overlap rate plot"
+    doc: "Condition 1 peak overlap rate plot"
+    outputSource: diffbind/peak_overlap_rate_plot_cond_1
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'Condition 1 peak overlap rate plot'
+
+  diffbind_peak_overlap_rate_plot_cond_1_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "Condition 1 peak overlap rate plot"
+    doc: "Condition 1 peak overlap rate plot"
+    outputSource: diffbind/peak_overlap_rate_plot_cond_1_pdf
+
+  diffbind_peak_overlap_rate_plot_cond_2:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "Condition 2 peak overlap rate plot"
+    doc: "Condition 2 peak overlap rate plot"
+    outputSource: diffbind/peak_overlap_rate_plot_cond_2
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'Condition 2 peak overlap rate plot'
+
+  diffbind_peak_overlap_rate_plot_cond_2_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "Condition 2 peak overlap rate plot"
+    doc: "Condition 2 peak overlap rate plot"
+    outputSource: diffbind/peak_overlap_rate_plot_cond_2_pdf
+
+  diffbind_all_data_correlation_heatmap:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "Not filtered normalized counts correlation heatmap"
+    doc: "Not filtered normalized counts correlation heatmap"
+    outputSource: select_files/selected_all_norm_counts_corr_heatmap
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'Not filtered normalized counts correlation heatmap'
+
+  diffbind_all_data_correlation_heatmap_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "Not filtered normalized counts correlation heatmap"
+    doc: "Not filtered normalized counts correlation heatmap"
+    outputSource: select_files/selected_all_norm_counts_corr_heatmap_pdf
+
+  diffbind_db_sites_correlation_heatmap:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "Normalized counts correlation heatmap for significantly differentially bound sites"
+    doc: "Normalized counts correlation heatmap for significantly differentially bound sites"
+    outputSource: select_files/selected_diff_filtered_norm_counts_corr_heatmap
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'Normalized counts correlation heatmap for significantly differentially bound sites'
+
+  diffbind_db_sites_correlation_heatmap_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "Normalized counts correlation heatmap for significantly differentially bound sites"
+    doc: "Normalized counts correlation heatmap for significantly differentially bound sites"
+    outputSource: select_files/selected_diff_filtered_norm_counts_corr_heatmap_pdf
+
+  diffbind_db_sites_binding_heatmap:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "Binding heatmap for significantly differentially bound sites"
+    doc: "Binding heatmap for significantly differentially bound sites"
+    outputSource: select_files/selected_binding_heatmap
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'Binding heatmap for significantly differentially bound sites'
+
+  diffbind_db_sites_binding_heatmap_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "Binding heatmap for significantly differentially bound sites"
+    doc: "Binding heatmap for significantly differentially bound sites"
+    outputSource: select_files/selected_binding_heatmap_pdf
+
+  diffbind_pca_plot:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "PCA plot for significantly differentially bound sites"
+    doc: "PCA plot for significantly differentially bound sites"
+    outputSource: select_files/selected_diff_filtered_pca_plot
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'PCA plot for significantly differentially bound sites'
+
+  diffbind_pca_plot_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "PCA plot for significantly differentially bound sites"
+    doc: "PCA plot for significantly differentially bound sites"
+    outputSource: select_files/selected_diff_filtered_pca_plot_pdf
+
+  diffbind_all_pca_plot:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "PCA plot for all bound sites"
+    doc: "PCA plot for all bound sites"
+    outputSource: select_files/selected_all_pca_plot
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'PCA plot for all bound sites'
+
+  diffbind_all_pca_plot_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "PCA plot for all bound sites"
+    doc: "PCA plot for all bound sites"
+    outputSource: select_files/selected_all_pca_plot_pdf
+
+  diffbind_ma_plot:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "MA plot for significantly differentially bound sites"
+    doc: "MA plot for significantly differentially bound sites"
+    outputSource: select_files/selected_ma_plot   
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'MA plot for significantly differentially bound sites'
+
+  diffbind_ma_plot_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "MA plot for significantly differentially bound sites"
+    doc: "MA plot for significantly differentially bound sites"
+    outputSource: select_files/selected_ma_plot_pdf
+
+  diffbind_volcano_plot:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "Volcano plot for significantly differentially bound sites"
+    doc: "Volcano plot for significantly differentially bound sites"
+    outputSource: select_files/selected_volcano_plot
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'Volcano plot for for significantly differentially bound sites'
+
+  diffbind_volcano_plot_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "Volcano plot for significantly differentially bound sites"
+    doc: "Volcano plot for significantly differentially bound sites"
+    outputSource: select_files/selected_volcano_plot_pdf
+
+  diffbind_boxplot_plot:
+    type: File?
+    format: "http://edamontology.org/format_3603"
+    label: "Box plots of read distributions for significantly differentially bound sites"
+    doc: "Box plots of read distributions for significantly differentially bound sites"
+    outputSource: select_files/selected_boxplot  
+    'sd:visualPlugins':
+      - image:
+          tab: 'Plots'
+          Caption: 'Box plots of read distributions for significantly differentially bound sites'
+
+  diffbind_boxplot_plot_pdf:
+    type: File?
+    format: "http://edamontology.org/format_3508"
+    label: "Box plots of read distributions for significantly differentially bound sites"
+    doc: "Box plots of read distributions for significantly differentially bound sites"
+    outputSource: select_files/selected_boxplot_pdf
+
+  diffbind_stdout_log:
+    type: File
+    format: "http://edamontology.org/format_2330"
+    label: "diffbind stdout log"
+    doc: "diffbind stdout log"
+    outputSource: diffbind/stdout_log
+
+  diffbind_stderr_log:
+    type: File
+    format: "http://edamontology.org/format_2330"
+    label: "diffbind stderr log"
+    doc: "diffbind stderr log"
+    outputSource: diffbind/stderr_log
+
+
+steps:
+
+  pipe:
+    run:
+      cwlVersion: v1.0
+      class: ExpressionTool
+      inputs:
+        genome_coverage_files_cond_1:
+          type: File[]
+        genome_coverage_files_cond_2:
+          type: File[]
+        narrow_peaks_files_cond_1:
+          type:
+            - "null"
+            - File[]
+        narrow_peaks_files_cond_2:
+          type:
+            - "null"
+            - File[]
+        broad_peaks_files_cond_1:
+          type:
+            - "null"
+            - File[]
+        broad_peaks_files_cond_2:
+          type:
+            - "null"
+            - File[]
+      outputs:
+        coverage_files_cond_1:
+          type: File[]
+        coverage_files_cond_2:
+          type: File[]
+        n_peaks_files_cond_1:
+          type:
+            - "null"
+            - File[]
+        n_peaks_files_cond_2:
+          type:
+            - "null"
+            - File[]
+        b_peaks_files_cond_1:
+          type:
+            - "null"
+            - File[]
+        b_peaks_files_cond_2:
+          type:
+            - "null"
+            - File[]
+      expression: |
+        ${
+          var results = {};
+          var output_names = [
+            "coverage_files_cond_1",
+            "coverage_files_cond_2",
+            "n_peaks_files_cond_1",
+            "n_peaks_files_cond_2",
+            "b_peaks_files_cond_1",
+            "b_peaks_files_cond_2"
+          ];
+          var sources = [
+            inputs.genome_coverage_files_cond_1,
+            inputs.genome_coverage_files_cond_2,
+            inputs.narrow_peaks_files_cond_1,
+            inputs.narrow_peaks_files_cond_2,
+            inputs.broad_peaks_files_cond_1,
+            inputs.broad_peaks_files_cond_2
+          ];
+          for (var i = 0; i < sources.length; i++){
+            var current_source = sources[i];
+            var current_output_name = output_names[i];
+            results[current_output_name] = null;
+            if (current_source != null && current_source.length > 0){
+              for (var j = 0; j < current_source.length; j++){
+                    var new_item = current_source[j];
+                    new_item["basename"] = "u" + "_" + i + "_" + j+ "_" + new_item.basename;
+                    if (results[current_output_name] == null){
+                      results[current_output_name] = [new_item];
+                    } else {
+                      results[current_output_name].push(new_item);
+                    }
+              }
+            }
+          }
+          return results;
+        }
+    in:
+      genome_coverage_files_cond_1: genome_coverage_files_cond_1
+      genome_coverage_files_cond_2: genome_coverage_files_cond_2
+      narrow_peaks_files_cond_1: narrow_peaks_files_cond_1
+      narrow_peaks_files_cond_2: narrow_peaks_files_cond_2
+      broad_peaks_files_cond_1: broad_peaks_files_cond_1
+      broad_peaks_files_cond_2: broad_peaks_files_cond_2
+    out:
+      - coverage_files_cond_1
+      - coverage_files_cond_2
+      - n_peaks_files_cond_1
+      - n_peaks_files_cond_2
+      - b_peaks_files_cond_1
+      - b_peaks_files_cond_2
+
+  diffbind:
+    run: ../tools/diffbind-for-spikein.cwl
+    in:
+      read_files_cond_1: read_files_cond_1
+      read_files_cond_2: read_files_cond_2
+      spikein_read_files_cond_1: spikein_read_files_cond_1
+      spikein_read_files_cond_2: spikein_read_files_cond_2
+      peak_files_cond_1: peak_files_cond_1
+      peak_files_cond_2: peak_files_cond_2
+      name_cond_1: name_cond_1
+      name_cond_2: name_cond_2
+      sample_names_cond_1: sample_names_cond_1
+      sample_names_cond_2: sample_names_cond_2
+      cutoff_value: cutoff_value
+      cutoff_param: cutoff_param
+      analysis_method: analysis_method
+      blocked_attributes: blocked_attributes
+      blocked_file: blocked_file
+      min_overlap: min_overlap
+      rec_summits: rec_summits
+      use_common: use_common
+      threads: threads
+      peakformat:
+        default: "macs"
+    out:
+      - diff_filtered_report_deseq
+      - diff_filtered_report_deseq_blocked
+      - diff_filtered_report_edger
+      - diff_filtered_report_edger_blocked
+      - boxplot_deseq
+      - boxplot_deseq_blocked
+      - boxplot_edger
+      - boxplot_edger_blocked
+      - boxplot_deseq_pdf
+      - boxplot_deseq_blocked_pdf
+      - boxplot_edger_pdf
+      - boxplot_edger_blocked_pdf
+      - volcano_plot_deseq
+      - volcano_plot_deseq_blocked
+      - volcano_plot_edger
+      - volcano_plot_edger_blocked
+      - volcano_plot_deseq_pdf
+      - volcano_plot_deseq_blocked_pdf
+      - volcano_plot_edger_pdf
+      - volcano_plot_edger_blocked_pdf
+      - ma_plot_deseq
+      - ma_plot_deseq_blocked
+      - ma_plot_edger
+      - ma_plot_edger_blocked
+      - ma_plot_deseq_pdf
+      - ma_plot_deseq_blocked_pdf
+      - ma_plot_edger_pdf
+      - ma_plot_edger_blocked_pdf
+      - diff_filtered_pca_plot_deseq
+      - diff_filtered_pca_plot_deseq_blocked
+      - diff_filtered_pca_plot_edger
+      - diff_filtered_pca_plot_edger_blocked
+      - diff_filtered_pca_plot_deseq_pdf
+      - diff_filtered_pca_plot_deseq_blocked_pdf
+      - diff_filtered_pca_plot_edger_pdf
+      - diff_filtered_pca_plot_edger_blocked_pdf
+      - all_pca_plot_deseq
+      - all_pca_plot_deseq_blocked
+      - all_pca_plot_edger
+      - all_pca_plot_edger_blocked
+      - all_pca_plot_deseq_pdf
+      - all_pca_plot_deseq_blocked_pdf
+      - all_pca_plot_edger_pdf
+      - all_pca_plot_edger_blocked_pdf
+      - binding_heatmap_deseq
+      - binding_heatmap_deseq_blocked
+      - binding_heatmap_edger
+      - binding_heatmap_edger_blocked
+      - binding_heatmap_deseq_pdf
+      - binding_heatmap_deseq_blocked_pdf
+      - binding_heatmap_edger_pdf
+      - binding_heatmap_edger_blocked_pdf
+      - diff_filtered_norm_counts_corr_heatmap_deseq
+      - diff_filtered_norm_counts_corr_heatmap_deseq_blocked
+      - diff_filtered_norm_counts_corr_heatmap_edger
+      - diff_filtered_norm_counts_corr_heatmap_edger_blocked
+      - diff_filtered_norm_counts_corr_heatmap_deseq_pdf
+      - diff_filtered_norm_counts_corr_heatmap_deseq_blocked_pdf
+      - diff_filtered_norm_counts_corr_heatmap_edger_pdf
+      - diff_filtered_norm_counts_corr_heatmap_edger_blocked_pdf
+      - all_norm_counts_corr_heatmap_deseq
+      - all_norm_counts_corr_heatmap_deseq_blocked
+      - all_norm_counts_corr_heatmap_edger
+      - all_norm_counts_corr_heatmap_edger_blocked
+      - all_norm_counts_corr_heatmap_deseq_pdf
+      - all_norm_counts_corr_heatmap_deseq_blocked_pdf
+      - all_norm_counts_corr_heatmap_edger_pdf
+      - all_norm_counts_corr_heatmap_edger_blocked_pdf
+      - consensus_peak_venn_diagram
+      - raw_counts_corr_heatmap
+      - peak_overlap_corr_heatmap
+      - all_peak_overlap_rate_plot
+      - peak_overlap_rate_plot_cond_1
+      - peak_overlap_rate_plot_cond_2
+      - consensus_peak_venn_diagram_pdf
+      - raw_counts_corr_heatmap_pdf
+      - peak_overlap_corr_heatmap_pdf
+      - all_peak_overlap_rate_plot_pdf
+      - peak_overlap_rate_plot_cond_1_pdf
+      - peak_overlap_rate_plot_cond_2_pdf
+      - stdout_log
+      - stderr_log
+
+  filter_columns:
+    run: ../tools/custom-bash.cwl
+    in:
+      input_file: 
+        source: [analysis_method, blocked_attributes, diffbind/diff_filtered_report_deseq, diffbind/diff_filtered_report_deseq_blocked, diffbind/diff_filtered_report_edger, diffbind/diff_filtered_report_edger_blocked]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      script:
+        default: >
+          cat $0 | grep -v "Start" | awk
+          'BEGIN {print "chr\tstart\tend\tlength\tabs_summit\tpileup\t-log10(pvalue)\tfold_enrichment\t-log10(qvalue)\tname"}
+          {print $1"\t"$2"\t"$3"\t"$3-$2+1"\t0\t"NR"\t0\t0\t0\t0"}' > `basename $0`
+    out: [output_file]
+
+  assign_genes:
+      run: ../tools/iaintersect.cwl
+      in:
+        input_filename: filter_columns/output_file
+        annotation_filename: annotation_file
+        promoter_bp: promoter_dist
+        upstream_bp: upstream_dist
+      out: [result_file]
+
+  restore_columns:
+    run: ../tools/custom-bash.cwl
+    in:
+      input_file:
+        source: [analysis_method, blocked_attributes, diffbind/diff_filtered_report_deseq, diffbind/diff_filtered_report_deseq_blocked, diffbind/diff_filtered_report_edger, diffbind/diff_filtered_report_edger_blocked, assign_genes/result_file]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return [self[6], self[2]];
+                } else {
+                  return [self[6], self[3]];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return [self[6], self[4]];
+                } else {
+                  return [self[6], self[5]];
+                }
+              }
+          }
+      script:
+        default: |
+          cat $0 | grep -v "start" | sort -k 11n | cut -f 1-5,15 > iaintersect_result.tsv
+          cat $1 | grep -v "Start" > diffbind_result.tsv
+          HEADER=`head -n 1 $1`;
+          echo -e "Refseq_id\tGene_id\ttxStart\ttxEnd\tStrand\tRegion\t${HEADER}" > `basename $0`;
+          cat iaintersect_result.tsv | paste - diffbind_result.tsv >> `basename $0`
+          rm iaintersect_result.tsv diffbind_result.tsv
+    out: [output_file]
+
+  iaintersect_result_formatted:
+    run:
+      cwlVersion: v1.0
+      class: CommandLineTool
+      requirements:
+      - class: ScatterFeatureRequirement
+      - class: ShellCommandRequirement
+      inputs:
+        script:
+          type: string?
+          default: |
+            printf "refseq_id\tgene_id\ttxStart\ttxEnd\tstrand\tchrom\tstart\tend\tlength\tabssummit\tpileup\tlog10p\tfoldenrich\tlog10q\tregion\n" > iaintersect_result_formatted.tsv
+            awk -F'\t' '{printf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",$1,$2,$3,$4,$5,$7,$8,$9,len,"0","0","0","0","0","na")}' <(tail -n+2 $0) >> iaintersect_result_formatted.tsv
+          inputBinding:
+            position: 1
+        input_file_1:
+          type: File
+          inputBinding:
+            position: 2
+      outputs:
+        output_file_1:
+          type: File
+          outputBinding:
+            glob: iaintersect_result_formatted.tsv
+      baseCommand: ["bash", "-c"]
+    in:
+      input_file_1: restore_columns/output_file
+    out:
+    - output_file_1
+
+  iaintersect_result_formatted_for_setops:
+    run:
+      cwlVersion: v1.0
+      class: CommandLineTool
+      requirements:
+      - class: ScatterFeatureRequirement
+      - class: ShellCommandRequirement
+      inputs:
+        script:
+          type: string?
+          default: |
+            printf "refseq_id\tgene_id\ttxStart\ttxEnd\tstrand\tchrom\tstart\tend\tlength\tabssummit\tpileup\tlog10p\tfoldenrich\tlog10q\tregion\n" > iaintersect_result_formatted_for_setops.tsv
+            awk -F'\t' '{printf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",$1,$2,$3,$4,$5,$7,$8,$9,len,"0","0","0","0","0","na")}' <(tail -n+2 $0) >> iaintersect_result_formatted_for_setops.tsv
+          inputBinding:
+            position: 1
+        input_file_1:
+          type: File
+          inputBinding:
+            position: 2
+      outputs:
+        output_file_1:
+          type: File
+          outputBinding:
+            glob: iaintersect_result_formatted_for_setops.tsv
+      baseCommand: ["bash", "-c"]
+    in:
+      input_file_1: restore_columns/output_file
+    out:
+    - output_file_1
+
+  convert_to_bed:
+    run: ../tools/custom-bash.cwl
+    in:
+      input_file: restore_columns/output_file
+      script:
+        default: |
+          cat "$0" | awk -F "\t" 'NR==1 {for (i=1; i<=NF; i++) {ix[$i]=i} } NR>1 {color="255,0,0"; if ($ix["Fold"]<0) color="0,255,0"; print $ix["Chr"]"\t"$ix["Start"]"\t"$ix["End"]"\tPv="$ix["p-value"]+0.0";FDR="$ix["FDR"]+0.0"\t"1000"\t"$ix["Strand"]"\t"$ix["Start"]"\t"$ix["End"]"\t"color}' > `basename $0`
+    out: [output_file]
+
+  sort_bed:
+    run: ../tools/linux-sort.cwl
+    in:
+      unsorted_file: convert_to_bed/output_file
+      key:
+        default: ["1,1","2,2n"]
+    out: [sorted_file]
+
+  bed_to_bigbed:
+    run: ../tools/ucsc-bedtobigbed.cwl
+    in:
+      input_bed: sort_bed/sorted_file
+      bed_type:
+        default: "bed4+5"
+      chrom_length_file: chrom_length_file
+      output_filename:
+        source: sort_bed/sorted_file
+        valueFrom: $(self.basename.split('.').slice(0,-1).join('.') + ".bigBed")
+    out: [bigbed_file]
+
+  select_files:
+    in:
+      input_boxplot:
+        source: [analysis_method, blocked_attributes, diffbind/boxplot_deseq, diffbind/boxplot_deseq_blocked, diffbind/boxplot_edger, diffbind/boxplot_edger_blocked]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_boxplot_pdf:
+        source: [analysis_method, blocked_attributes, diffbind/boxplot_deseq_pdf, diffbind/boxplot_deseq_blocked_pdf, diffbind/boxplot_edger_pdf, diffbind/boxplot_edger_blocked_pdf]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_volcano_plot:
+        source: [analysis_method, blocked_attributes, diffbind/volcano_plot_deseq, diffbind/volcano_plot_deseq_blocked, diffbind/volcano_plot_edger, diffbind/volcano_plot_edger_blocked]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_volcano_plot_pdf:
+        source: [analysis_method, blocked_attributes, diffbind/volcano_plot_deseq_pdf, diffbind/volcano_plot_deseq_blocked_pdf, diffbind/volcano_plot_edger_pdf, diffbind/volcano_plot_edger_blocked_pdf]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_ma_plot:
+        source: [analysis_method, blocked_attributes, diffbind/ma_plot_deseq, diffbind/ma_plot_deseq_blocked, diffbind/ma_plot_edger, diffbind/ma_plot_edger_blocked]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_ma_plot_pdf:
+        source: [analysis_method, blocked_attributes, diffbind/ma_plot_deseq_pdf, diffbind/ma_plot_deseq_blocked_pdf, diffbind/ma_plot_edger_pdf, diffbind/ma_plot_edger_blocked_pdf]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_diff_filtered_pca_plot:
+        source: [analysis_method, blocked_attributes, diffbind/diff_filtered_pca_plot_deseq, diffbind/diff_filtered_pca_plot_deseq_blocked, diffbind/diff_filtered_pca_plot_edger, diffbind/diff_filtered_pca_plot_edger_blocked]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_diff_filtered_pca_plot_pdf:
+        source: [analysis_method, blocked_attributes, diffbind/diff_filtered_pca_plot_deseq_pdf, diffbind/diff_filtered_pca_plot_deseq_blocked_pdf, diffbind/diff_filtered_pca_plot_edger_pdf, diffbind/diff_filtered_pca_plot_edger_blocked_pdf]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_all_pca_plot:
+        source: [analysis_method, blocked_attributes, diffbind/all_pca_plot_deseq, diffbind/all_pca_plot_deseq_blocked, diffbind/all_pca_plot_edger, diffbind/all_pca_plot_edger_blocked]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_all_pca_plot_pdf:
+        source: [analysis_method, blocked_attributes, diffbind/all_pca_plot_deseq_pdf, diffbind/all_pca_plot_deseq_blocked_pdf, diffbind/all_pca_plot_edger_pdf, diffbind/all_pca_plot_edger_blocked_pdf]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_binding_heatmap:
+        source: [analysis_method, blocked_attributes, diffbind/binding_heatmap_deseq, diffbind/binding_heatmap_deseq_blocked, diffbind/binding_heatmap_edger, diffbind/binding_heatmap_edger_blocked]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_binding_heatmap_pdf:
+        source: [analysis_method, blocked_attributes, diffbind/binding_heatmap_deseq_pdf, diffbind/binding_heatmap_deseq_blocked_pdf, diffbind/binding_heatmap_edger_pdf, diffbind/binding_heatmap_edger_blocked_pdf]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_diff_filtered_norm_counts_corr_heatmap:
+        source: [analysis_method, blocked_attributes, diffbind/diff_filtered_norm_counts_corr_heatmap_deseq, diffbind/diff_filtered_norm_counts_corr_heatmap_deseq_blocked, diffbind/diff_filtered_norm_counts_corr_heatmap_edger, diffbind/diff_filtered_norm_counts_corr_heatmap_edger_blocked]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_diff_filtered_norm_counts_corr_heatmap_pdf:
+        source: [analysis_method, blocked_attributes, diffbind/diff_filtered_norm_counts_corr_heatmap_deseq_pdf, diffbind/diff_filtered_norm_counts_corr_heatmap_deseq_blocked_pdf, diffbind/diff_filtered_norm_counts_corr_heatmap_edger_pdf, diffbind/diff_filtered_norm_counts_corr_heatmap_edger_blocked_pdf]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_all_norm_counts_corr_heatmap:
+        source: [analysis_method, blocked_attributes, diffbind/all_norm_counts_corr_heatmap_deseq, diffbind/all_norm_counts_corr_heatmap_deseq_blocked, diffbind/all_norm_counts_corr_heatmap_edger, diffbind/all_norm_counts_corr_heatmap_edger_blocked]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+      input_all_norm_counts_corr_heatmap_pdf:
+        source: [analysis_method, blocked_attributes, diffbind/all_norm_counts_corr_heatmap_deseq_pdf, diffbind/all_norm_counts_corr_heatmap_deseq_blocked_pdf, diffbind/all_norm_counts_corr_heatmap_edger_pdf, diffbind/all_norm_counts_corr_heatmap_edger_blocked_pdf]
+        valueFrom: |
+          ${
+              if (self[0] == "deseq2") {
+                if (self[1] == null || self[1].length == 0){
+                  return self[2];
+                } else {
+                  return self[3];
+                }
+              } else {
+                if (self[1] == null || self[1].length == 0){
+                  return self[4];
+                } else {
+                  return self[5];
+                }
+              }
+          }
+    out:
+      - selected_boxplot
+      - selected_volcano_plot
+      - selected_ma_plot
+      - selected_diff_filtered_pca_plot
+      - selected_all_pca_plot
+      - selected_binding_heatmap
+      - selected_diff_filtered_norm_counts_corr_heatmap
+      - selected_all_norm_counts_corr_heatmap
+      - selected_boxplot_pdf
+      - selected_volcano_plot_pdf
+      - selected_ma_plot_pdf
+      - selected_diff_filtered_pca_plot_pdf
+      - selected_all_pca_plot_pdf
+      - selected_binding_heatmap_pdf
+      - selected_diff_filtered_norm_counts_corr_heatmap_pdf
+      - selected_all_norm_counts_corr_heatmap_pdf
+    run:
+      cwlVersion: v1.0
+      class: ExpressionTool
+      requirements:
+        - class: InlineJavascriptRequirement
+      inputs:
+        input_boxplot:
+          type: File?
+        input_boxplot_pdf:
+          type: File?
+        input_volcano_plot:
+          type: File?
+        input_volcano_plot_pdf:
+          type: File?
+        input_ma_plot:
+          type: File?
+        input_ma_plot_pdf:
+          type: File?
+        input_diff_filtered_pca_plot:
+          type: File?
+        input_diff_filtered_pca_plot_pdf:
+          type: File?        
+        input_all_pca_plot:
+          type: File?
+        input_all_pca_plot_pdf:
+          type: File?        
+        input_binding_heatmap:
+          type: File?
+        input_binding_heatmap_pdf:
+          type: File?          
+        input_diff_filtered_norm_counts_corr_heatmap:
+          type: File?
+        input_diff_filtered_norm_counts_corr_heatmap_pdf:
+          type: File?
+        input_all_norm_counts_corr_heatmap:
+          type: File?
+        input_all_norm_counts_corr_heatmap_pdf:
+          type: File?
+      outputs:
+        selected_boxplot:
+          type: File?
+        selected_volcano_plot:
+          type: File?
+        selected_ma_plot:
+          type: File?
+        selected_diff_filtered_pca_plot:
+          type: File?
+        selected_all_pca_plot:
+          type: File?
+        selected_binding_heatmap:
+          type: File?
+        selected_diff_filtered_norm_counts_corr_heatmap:
+          type: File?
+        selected_all_norm_counts_corr_heatmap:
+          type: File?
+        selected_boxplot_pdf:
+          type: File?
+        selected_volcano_plot_pdf:
+          type: File?
+        selected_ma_plot_pdf:
+          type: File?
+        selected_diff_filtered_pca_plot_pdf:
+          type: File?
+        selected_all_pca_plot_pdf:
+          type: File?
+        selected_binding_heatmap_pdf:
+          type: File?
+        selected_diff_filtered_norm_counts_corr_heatmap_pdf:
+          type: File?
+        selected_all_norm_counts_corr_heatmap_pdf:
+          type: File?
+      expression: |
+        ${
+          return {
+            "selected_boxplot": inputs.input_boxplot,
+            "selected_volcano_plot": inputs.input_volcano_plot,
+            "selected_ma_plot": inputs.input_ma_plot,
+            "selected_diff_filtered_pca_plot": inputs.input_diff_filtered_pca_plot,
+            "selected_all_pca_plot": inputs.input_all_pca_plot,
+            "selected_binding_heatmap": inputs.input_binding_heatmap,
+            "selected_diff_filtered_norm_counts_corr_heatmap": inputs.input_diff_filtered_norm_counts_corr_heatmap,
+            "selected_all_norm_counts_corr_heatmap": inputs.input_all_norm_counts_corr_heatmap,
+            "selected_boxplot_pdf": inputs.input_boxplot_pdf,
+            "selected_volcano_plot_pdf": inputs.input_volcano_plot_pdf,
+            "selected_ma_plot_pdf": inputs.input_ma_plot_pdf,
+            "selected_diff_filtered_pca_plot_pdf": inputs.input_diff_filtered_pca_plot_pdf,
+            "selected_all_pca_plot_pdf": inputs.input_all_pca_plot_pdf,
+            "selected_binding_heatmap_pdf": inputs.input_binding_heatmap_pdf,
+            "selected_diff_filtered_norm_counts_corr_heatmap_pdf": inputs.input_diff_filtered_norm_counts_corr_heatmap_pdf,
+            "selected_all_norm_counts_corr_heatmap_pdf": inputs.input_all_norm_counts_corr_heatmap_pdf
+          };
+        }
+
+      
+$namespaces:
+  s: http://schema.org/
+
+$schemas:
+- https://github.com/schemaorg/schemaorg/raw/main/data/releases/11.01/schemaorg-current-http.rdf
+
+label: "DiffBind spike-in - Differential Binding Analysis of ChIP-Seq or CUTß&RUN/Tag Peak Data with spike-in"
+s:name: "DiffBind spike-in - Differential Binding Analysis of ChIP-Seq or CUT&RUN/Tag Peak Data with spike-in"
+s:alternateName: "Compute differentially bound sites from multiple ChIP-seq or CUT&RUN/Tag experiments using affinity (quantitative) and occupancy data that has a spike-in control."
+
+s:downloadUrl: https://raw.githubusercontent.com/datirium/workflows/master/workflows/diffbind.cwl
+s:codeRepository: https://github.com/datirium/workflows
+s:license: http://www.apache.org/licenses/LICENSE-2.0
+
+s:isPartOf:
+  class: s:CreativeWork
+  s:name: Common Workflow Language
+  s:url: http://commonwl.org/
+
+s:creator:
+  - class: s:Organization
+    s:legalName: "Cincinnati Children's Hospital Medical Center"
+    s:location:
+    - class: s:PostalAddress
+      s:addressCountry: "USA"
+      s:addressLocality: "Cincinnati"
+      s:addressRegion: "OH"
+      s:postalCode: "45229"
+      s:streetAddress: "3333 Burnet Ave"
+      s:telephone: "+1(513)636-4200"
+    s:logo: "https://www.cincinnatichildrens.org/-/media/cincinnati%20childrens/global%20shared/childrens-logo-new.png"
+    s:department:
+    - class: s:Organization
+      s:legalName: "Allergy and Immunology"
+      s:department:
+      - class: s:Organization
+        s:legalName: "Barski Research Lab"
+        s:member:
+        - class: s:Person
+          s:name: Michael Kotliar
+          s:email: mailto:michael.kotliar@cchmc.org
+          s:sameAs:
+          - id: http://orcid.org/0000-0002-6486-3898
+
+
+# doc:
+#   $include: ../descriptions/diffbind.md
+
+
+doc: |
+  Differential Binding Analysis of ChIP-Seq, ATAC-Seq, or CUT&RUN/Tag Peak Data with spike-in
+  ---------------------------------------------------
+  
+  DiffBind processes ChIP-Seq, ATAC-Seq, or CUT&RUN/Tag data enriched for genomic loci where specific
+  protein/DNA binding occurs, including peak sets identified by peak caller tools and aligned
+  sequence read datasets. It is designed to work with multiple peak sets simultaneously,
+  representing different ChIP, ATAC, or CUT&RUN/Tag experiments (antibodies, transcription factor
+  and/or histone marks, experimental conditions, replicates) as well as managing the results
+  of multiple peak callers. This specific workflow is designed for experiments that use a spike-in
+  control for each sample. These spike-in reads are used to normalize the datasets during differential
+  analysis using the RLE method (for either edgeR or DESeq) while accounting for background (spike-in).
+
+  For more information please refer to:
+  -------------------------------------
+  Ross-Innes CS, Stark R, Teschendorff AE, Holmes KA, Ali HR, Dunning MJ, Brown GD, Gojis O,
+  Ellis IO, Green AR, Ali S, Chin S, Palmieri C, Caldas C, Carroll JS (2012). “Differential
+  oestrogen receptor binding is associated with clinical outcome in breast cancer.” Nature,
+  481, -4.


### PR DESCRIPTION
- Li-Chun OSU6 custom work
- includes updates to chip-seq PE spike-in workflow for diffbind spike-in norm worklow compatibility
- raw macs2 peak calls are input for diffbind spike-in workflow, while the scaled peak and bigwig files are used for visualizations for individual spike-in chip samples.
- BAM files from spike-in reference genome alignment per sample are used as input for diffbind for background normalization using RLE method (for either edgeR or deseq, depends on user).