### PR TITLE
DESeq2 updated to v.28

### DIFF
--- a/dockerfiles/scidap-deseq-Dockerfile
+++ b/dockerfiles/scidap-deseq-Dockerfile
@@ -2,35 +2,33 @@
 # Dockerfile
 #
 # Software:         BioWardrobe DESeq/DESeq2 script
-# Software Version: v0.0.27
+# Software Version: v0.0.28
 # Description:      Dockerized version of DESeq/DESeq2 script from BioWardrobe
 # Website:          https://github.com/Barski-lab/workflows
 # Provides:         run_deseq.R
 #                   run_deseq_lrt.R
 #                   get_gene_n_tss.R
 #                   run_deseq_manual.R
-#                   BiocManager       1.30.10
-#                   BiocParallel      1.22.0
-#                   DESeq             1.39.0
-#                   DESeq2            1.28.1
+#                   BiocManager       1.30.23
+#                   BiocParallel      1.38.0
+#                   DESeq2            1.44.0
 #                   argparse          latest
 #                   pheatmap          latest
-# Base Image:       r-base:4.0.2
-# Build Cmd:        docker build --no-cache --rm -t deseq-dev -f scidap-deseq-Dockerfile . > ~/Desktop/dockerbuild.log 2>&1
-# Run Cmd:          docker run --rm -ti deseq-dev /bin/bash
-# Push Cmd1:        docker tag deseq-dev robertplayer/scidap-deseq:dev
-#      Cmd2:        docker image push robertplayer/scidap-deseq:dev
-# Pull Cmd:         docker pull robertplayer/scidap-deseq:dev
-# Test dev:         docker run --rm -ti robertplayer/scidap-deseq:dev /bin/bash
-# re-tag for PR:    docker tag deseq-dev robertplayer/scidap-deseq:v1.0.0
-# Push for PR:      docker image push robertplayer/scidap-deseq:v1.0.0
-# Test vx.x.x:      docker run --rm -ti robertplayer/scidap-deseq:v1.0.0 /bin/bash
+# Base Image:       r-base:4.4.0
+# Build Cmd:        docker build --no-cache --platform linux/amd64 --rm -t biowardrobe2/scidap-deseq:v0.0.28 -f scidap-deseq-Dockerfile .
+# Pull Cmd:         docker pull biowardrobe2/scidap-deseq:v0.0.28
+# Run Cmd:          docker run --rm -ti biowardrobe2/scidap-deseq:v0.0.28 /bin/bash
 #################################################################
 #
-# v1.0.0
-# - Update run_deseq.R to output both all genes and filtered gene list by padj
-# - also copied this dockerfile and the run_deseq.R script from Barski lab to Datirium repo
+# v0.0.28
 #
+# - Added optional --batchcorrection parameter for DESeq2 (combatseq (provided design-formula) or limma)
+# - Changed default adjusted p-value to 0.1 (in correspondance with alpha)
+# - Added regulation parameter for DESeq2 (up, down, both) and appropriate altHypothesis
+# - Added --lfcthreshold parameter for DESeq2 (changed default to 0.59, because it has more biological sense)
+# - Changed center to min-max scaling before HOPACH clustering
+# - Added blind = F parameter for DESeq2 vst and rlog (to take into account design-formula)
+# - Removed RPKM filtering (not needed for DESeq2 as explained by developer while independence filtering provided)
 #
 # v0.0.27
 # - Update run_deseq.R to export baseMean column
@@ -162,56 +160,52 @@
 #################################################################
 
 
-### Base Image
-# FROM r-base:4.0.4     # this is the original, initial base image; pulled from Barski lab repo, so building from that base
-# FROM biowardrobe2/scidap-deseq:v0.0.27    # for faster build tests
-# for even faster build tests, run from latest stable build
-FROM robertplayer/scidap-deseq:dev
-LABEL maintainer="robert.player@datirium.com"
+# Base Image
+FROM r-base:4.4.0
+LABEL maintainer="pavlvalera3301@gmail.com"
 ENV DEBIAN_FRONTEND noninteractive
 
 ################## BEGIN INSTALLATION ######################
 
 WORKDIR /tmp
 
-ENV VERSION_BIOCMANAGER 1.30.19
-ENV URL_BIOCMANAGER "https://cran.r-project.org/src/contrib/BiocManager_${VERSION_BIOCMANAGER}.tar.gz"
-ENV VERSION_LOCFIT 1.5-9.4
-ENV URL_LOCFIT "https://cran.r-project.org/src/contrib/Archive/locfit/locfit_${VERSION_LOCFIT}.tar.gz"
-
+# Copying scripts
 COPY ./scripts/install_from_source.R /tmp/install_from_source.R
 COPY ./scripts/run_deseq.R /usr/local/bin/run_deseq.R
 COPY ./scripts/run_deseq_lrt.R /usr/local/bin/run_deseq_lrt.R
 COPY ./scripts/get_gene_n_tss.R /usr/local/bin/get_gene_n_tss.R
+# Copy the install_packages.R script into the Docker image
+COPY ./scripts/docker_R_packages_installation/scidap-deseq-R-packages.R /tmp/scidap-deseq-R-packages.R
 
-### Installing python3, pip3 and argparse
-RUN apt-get update && \
-    apt-get install -y gcc-10-base libgcc-10-dev python3-dev python3-pip libxml2-dev libssl-dev libcurl4-openssl-dev \
-                        pandoc libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype-dev libpng-dev libtiff5-dev \
-                        libjpeg-dev vim && \
-    pip3 install argparse --break-system-packages && \
-    # Installing biocmanager, biocparallel, deseq, deseq2, argparse, pheatmap
-    Rscript /tmp/install_from_source.R "${URL_BIOCMANAGER}" && \
-    Rscript /tmp/install_from_source.R "${URL_LOCFIT}" && \
-    R -e "BiocManager::install(version = '3.11', update=FALSE, ask=FALSE)" && \
-    R -e "BiocManager::install(c('BiocParallel', 'DESeq', 'DESeq2', 'limma', 'EnhancedVolcano', 'hopach', 'cmapR'), update=TRUE, ask=FALSE)" && \
-    R -e 'install.packages("tidyverse", repo = "https://cloud.r-project.org/")' && \
-    R -e 'install.packages("patchwork", repo = "https://cloud.r-project.org/")' && \
-    R -e 'install.packages("argparse", repo = "https://cloud.r-project.org/")' && \
-    R -e 'install.packages("data.table", repo = "https://cloud.r-project.org/")' && \
-    R -e 'install.packages("pheatmap", repo = "https://cloud.r-project.org/")' && \
-    R -e 'install.packages("ggrepel", repo = "https://cloud.r-project.org/")' && \
-    R -e 'install.packages("htmlwidgets", repo = "https://cloud.r-project.org/")' && \
-    R -e 'install.packages("devtools", repo = "https://cloud.r-project.org/")' && \
-    R -e 'devtools::install_github("hasaru-k/GlimmaV2")' && \
-    # make script executable from $PATH
-    chmod +x /usr/local/bin/run_deseq.R && \
-    ls -la /usr/local/bin/run_deseq.R && \
-    chmod +x /usr/local/bin/run_deseq_lrt.R && \
-    ls -la /usr/local/bin/run_deseq_lrt.R && \
-    chmod +x /usr/local/bin/get_gene_n_tss.R && \
-    ls -la /usr/local/bin/get_gene_n_tss.R && \
-    # Cleaning
+# Update the sources list to use the Debian Bullseye repository
+RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.list
+
+# Installing python3, pip3 and argparse and other dependencies
+RUN apt-get update --fix-missing && apt-get install -f -y
+
+RUN apt-get install -y -f python3 python3-pip \
+                          build-essential \
+                          libcurl4-openssl-dev \
+                          libssl-dev \
+                          libxml2-dev \
+                          libharfbuzz-dev \
+                          libfribidi-dev \
+                          libpng-dev \
+                          libfontconfig1-dev \
+                          libtiff5-dev \
+                          libcairo2-dev \
+                          pkg-config \
+                          libjpeg-dev \
+                          libgit2-dev && \
+    pip3 install --break-system-packages argparse && \
+# Installing R packages
+    Rscript /tmp/scidap-deseq-R-packages.R
+# Installing run_deseq.R, get_gene_n_tss.R, run_deseq_lrt.R scripts
+# and setting permissions to make them executable
+RUN  chmod +x /usr/local/bin/run_deseq.R && \
+     chmod +x /usr/local/bin/run_deseq_lrt.R && \
+     chmod +x /usr/local/bin/get_gene_n_tss.R && \
+# Cleaning
     apt-get clean && \
     apt-get purge && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* && \

--- a/dockerfiles/scripts/run_deseq.R
+++ b/dockerfiles/scripts/run_deseq.R
@@ -18,6 +18,16 @@ suppressMessages(library(ggrepel))
 
 
 ##########################################################################################
+# v0.0.28
+#
+# - Added optional --batchcorrection parameter for DESeq2 (combatseq (provided design-formula) or limma)
+# - Changed default adjusted p-value to 0.1 (in correspondance with alpha)
+# - Added regulation parameter for DESeq2 (up, down, both) and appropriate altHypothesis
+# - Added --lfcthreshold parameter for DESeq2 (changed default to 0.59, because it has more biological sense)
+# - Changed center to min-max scaling before HOPACH clustering
+# - Added blind = F parameter for DESeq2 vst and rlog (to take into account design-formula)
+# - Removed RPKM filtering (not needed for DESeq2 as explained by developer while independence filtering provided)
+#
 #
 # v1.0.0
 # - Update run_deseq.R to output both all genes and filtered gene list by padj
@@ -124,13 +134,13 @@ RPKM_UNTREATED_ALIAS <- "RpkmCondition1"
 RPKM_TREATED_ALIAS <- "RpkmCondition2"
 
 
-get_file_type <- function (filename) {
-    ext = tools::file_ext(filename)
-    separator = ","
-    if (ext == "tsv"){
-        separator = "\t"
-    }
-    return (separator)
+get_file_type <- function(filename) {
+  ext <- tools::file_ext(filename)
+  separator <- ","
+  if (ext == "tsv") {
+    separator <- "\t"
+  }
+  return(separator)
 }
 
 
@@ -201,7 +211,8 @@ export_cls <- function(categories, location){
                 base::paste(
                     base::paste(
                         as.character(categories),
-                        collapse="\t"
+                        collapse=
+                          "\t"
                     ),
                     sep="\t"
                 ),
@@ -216,83 +227,202 @@ export_cls <- function(categories, location){
     )
 }
 
+# Define the function to generate the markdown file
+generate_md <- function(batchcorrection, batchfile, deseq_results, output_file) {
+  # Initialize the markdown content
+  md_content <- ""
 
-get_clustered_data <- function(expression_data, center, dist, transpose) {
+  # Add warning message if applicable
+  if (!is.null(batchcorrection) && (batchcorrection == "combatseq" || batchcorrection == "limmaremovebatcheffect") && is.null(batchfile)) {
+    warning_message <- "# Warning!\n\n---\n\n**You provided a batch-correction method, but not a batch-file.**\n\nThe chosen parameter was ignored.\n\nPlease ensure that you provide a batch file when using the following batch correction methods:\n\n- **combatseq**\n- **limmaremovebatcheffect**\n\nIf you do not need batch correction, set the method to 'none'.\n\n---\n\n"
+    md_content <- paste0(md_content, warning_message)
+  }
 
-    if (transpose){
-        print("Transposing expression data")
-        expression_data = t(expression_data)
-    }
-    if (!is.null(center)) {
-        print(paste("Centering expression data by ", center, sep=""))
-        if (center == "mean"){
-            expression_data = expression_data - rowMeans(expression_data)    
-        } else {
-            expression_data = expression_data - rowMedians(data.matrix(expression_data))    
-        }
-    }
-    print("Creating distance matrix")
-    distance_matrix <- distancematrix(expression_data, dist)
-    print("Running HOPACH")
-    hopach_results <- hopach(expression_data, dmat=distance_matrix)
+  # Add DESeq results summary if provided
+  if (!is.null(deseq_results)) {
+    # Capture the summary output
+    summary_output <- capture.output({
+      summary(deseq_results)
+    })
 
-    if (transpose){
-        print("Transposing expression data")
-        expression_data = t(expression_data)
-    }
+    # Parse the relevant information
+    total_genes <- gsub(" with nonzero total read count", "", summary_output[2])
+    total_genes <- gsub("out of ", "", total_genes)
+    fdr_pvalue <- gsub("adjusted p-value < ", "", summary_output[3])
+    lfc_up <- gsub(".*: ", "", summary_output[4])
+    lfc_down <- gsub(".*: ", "", summary_output[5])
+    outliers <- gsub(".*: ", "", summary_output[6])
+    low_counts <- gsub(".*: ", "", summary_output[7])
+    mean_count <- gsub("[^0-9]", "", summary_output[8])
 
-    print("Parsing cluster labels")
-    clusters = as.data.frame(hopach_results$clustering$labels)
-    colnames(clusters) = "label"
-    clusters = cbind(
-        clusters,
-        "HCL"=outer(
-            clusters$label,
-            10^c((nchar(trunc(clusters$label))[1]-1):0),
-            function(a, b) {
-                paste0("c", a %/% b %% 10)
-            }
-        )
+    # Extract the LFC threshold from the summary output
+    lfc_threshold <- gsub(".*LFC > ", "", summary_output[4])
+    lfc_threshold <- gsub(" \\(up\\).*", "", lfc_threshold)
+
+    # Create a data frame
+    summary_df <- data.frame(
+      Metric = c(
+        "Total genes with non-zero read count",
+        paste("LFC >", lfc_threshold, "(up)"),
+        paste("LFC &lt;", lfc_threshold, "(down)"),
+        "Outliers<sup>1</sup>",
+        paste0("Low counts<sup>2</sup> (mean count &lt; ", mean_count, ")", collapse = "")
+      ),
+      Value = c(total_genes, lfc_up, lfc_down, outliers, low_counts),
+      stringsAsFactors = FALSE
     )
-    clusters = clusters[, c(-1), drop=FALSE]
 
-    return (
-        list(
-            order=as.vector(hopach_results$clustering$order),
-            expression=expression_data,
-            clusters=clusters
-        )
+    # Convert the data frame to markdown format using kable
+    summary_output_md <- paste0(
+      "# DESeq2 Results Summary\n\n---\n\n",
+      "## Summary of DESeq2 Results\n\n",
+      kableExtra::kable(summary_df, format = "html", escape = FALSE) %>%
+        kableExtra::kable_styling(bootstrap_options = c("striped", "hover", "condensed"), full_width = F),
+      "\n\narguments of ?DESeq2::results():   \n<sup>1</sup> - see 'cooksCutoff',\n<sup>2</sup> - see 'independentFiltering'\n\n---\n\n"
     )
+
+    md_content <- paste0(md_content, summary_output_md)
+  }
+
+  # Write the content to the output file
+  writeLines(md_content, con = output_file)
 }
 
+get_clustered_data <- function(expression_data, dist, transpose) {
+  if (transpose) {
+    print("Transposing expression data")
+    expression_data <- t(expression_data)
+  }
 
-load_isoform_set <- function(filenames, prefixes, read_colname, rpkm_colname, rpkm_colname_alias, conditions, intersect_by, digits, batch_metadata, collected_data=NULL) {
-    for (i in 1:length(filenames)) {
-        isoforms <- read.table(filenames[i], sep=get_file_type(filenames[i]), header=TRUE, stringsAsFactors=FALSE)
-        new_read_colname = paste(prefixes[i], conditions, sep="_")
-        colnames(isoforms)[colnames(isoforms) == read_colname] <- new_read_colname
-        colnames(isoforms)[colnames(isoforms) == rpkm_colname] <- paste(conditions, i, rpkm_colname, sep=" ")
-        if (!is.null(batch_metadata)){
-            batch <- batch_metadata[prefixes[i], "batch"]
-            print(paste("Load ", nrow(isoforms), " rows from '", filenames[i], "' as '", new_read_colname, "', batch '", batch, "'", sep=""))
-            column_data_frame <- data.frame(conditions, batch, row.names=c(new_read_colname))
-        } else {
-            print(paste("Load ", nrow(isoforms), " rows from '", filenames[i], "' as '", new_read_colname, "'", sep=""))
-            column_data_frame <- data.frame(conditions, row.names=c(new_read_colname))
-        }
-        if (is.null(collected_data)){
-            collected_data = list(collected_isoforms=isoforms, read_colnames=c(new_read_colname), column_data=column_data_frame)
-        } else {
-            collected_data$collected_isoforms <- merge(collected_data$collected_isoforms, isoforms, by=intersect_by, sort = FALSE)
-            collected_data$read_colnames = c(collected_data$read_colnames, new_read_colname)
-            collected_data$column_data <- rbind(collected_data$column_data, column_data_frame)
-        }
+  expression_data <- apply(
+    expression_data,
+    1,
+    FUN = function(x) {
+      scale_min_max(x)
     }
-    rpkm_columns = grep(paste("^", conditions, " [0-9]+ ", rpkm_colname, sep=""), colnames(collected_data$collected_isoforms), value = TRUE, ignore.case = TRUE)
-    collected_data$collected_isoforms[rpkm_colname_alias] = format(rowSums(collected_data$collected_isoforms[, rpkm_columns, drop = FALSE]) / length(filenames), digits=digits)
-    collected_data$rpkm_colnames = c(collected_data$rpkm_colnames, rpkm_colname_alias)
-    collected_data$collected_isoforms <- collected_data$collected_isoforms[, !colnames(collected_data$collected_isoforms) %in% rpkm_columns]
-    return( collected_data )
+  )
+
+  print("Running HOPACH")
+  hopach_results <- hopach(expression_data)
+
+  if (transpose) {
+    print("Transposing expression data")
+    expression_data <- t(expression_data)
+  }
+
+  print("Parsing cluster labels")
+  clusters <- as.data.frame(hopach_results$clustering$labels)
+  colnames(clusters) <- "label"
+  clusters <- cbind(clusters, "HCL" = outer(clusters$label, 10^c((nchar(
+    trunc(clusters$label)
+  )[1] - 1):0), function(a, b) {
+    paste0("c", a %/% b %% 10)
+  }))
+  clusters <- clusters[, c(-1), drop = FALSE]
+
+  return(list(
+    order = as.vector(hopach_results$clustering$order),
+    expression = expression_data,
+    clusters = clusters
+  ))
+}
+
+scale_min_max <- function(x,
+                          min_range = -2,
+                          max_range = 2) {
+  min_val <- min(x)
+  max_val <- max(x)
+  scaled_x <-
+    (x - min_val) / (max_val - min_val) * (max_range - min_range) + min_range
+  return(scaled_x)
+}
+
+load_isoform_set <- function(filenames,
+                             prefixes,
+                             read_colname,
+                             rpkm_colname,
+                             rpkm_colname_alias,
+                             conditions,
+                             intersect_by,
+                             digits,
+                             batch_metadata,
+                             collected_data = NULL) {
+  for (i in 1:length(filenames)) {
+    isoforms <- read.table(
+      filenames[i],
+      sep = get_file_type(filenames[i]),
+      header = TRUE,
+      stringsAsFactors = FALSE
+    )
+    new_read_colname <- paste(prefixes[i], conditions, sep = "_")
+    colnames(isoforms)[colnames(isoforms) == read_colname] <- new_read_colname
+    colnames(isoforms)[colnames(isoforms) == rpkm_colname] <- paste(conditions, i, rpkm_colname,
+      sep =
+        " "
+    )
+    if (!is.null(batch_metadata)) {
+      batch <- batch_metadata[prefixes[i], "batch"]
+      print(
+        paste(
+          "Load ",
+          nrow(isoforms),
+          " rows from '",
+          filenames[i],
+          "' as '",
+          new_read_colname,
+          "', batch '",
+          batch,
+          "'",
+          sep = ""
+        )
+      )
+      column_data_frame <- data.frame(conditions, batch,
+        row.names =
+          c(new_read_colname)
+      )
+    } else {
+      print(
+        paste(
+          "Load ",
+          nrow(isoforms),
+          " rows from '",
+          filenames[i],
+          "' as '",
+          new_read_colname,
+          "'",
+          sep = ""
+        )
+      )
+      column_data_frame <- data.frame(conditions, row.names = c(new_read_colname))
+    }
+    if (is.null(collected_data)) {
+      collected_data <- list(
+        collected_isoforms = isoforms,
+        read_colnames = c(new_read_colname),
+        column_data = column_data_frame
+      )
+    } else {
+      collected_data$collected_isoforms <- merge(collected_data$collected_isoforms,
+        isoforms,
+        by = intersect_by,
+        sort = FALSE
+      )
+      collected_data$read_colnames <- c(collected_data$read_colnames, new_read_colname)
+      collected_data$column_data <- rbind(collected_data$column_data, column_data_frame)
+    }
+  }
+  rpkm_columns <- grep(
+    paste("^", conditions, " [0-9]+ ", rpkm_colname, sep = ""),
+    colnames(collected_data$collected_isoforms),
+    value = TRUE,
+    ignore.case = TRUE
+  )
+  collected_data$collected_isoforms[rpkm_colname_alias] <- format(rowSums(collected_data$collected_isoforms[, rpkm_columns, drop = FALSE]) / length(filenames),
+    digits = digits
+  )
+  collected_data$rpkm_colnames <- c(collected_data$rpkm_colnames, rpkm_colname_alias)
+  collected_data$collected_isoforms <- collected_data$collected_isoforms[, !colnames(collected_data$collected_isoforms) %in% rpkm_columns]
+  return(collected_data)
 }
 
 
@@ -391,53 +521,58 @@ export_heatmap <- function(mat_data, column_data, rootname, width=800, height=80
 }
 
 
-apply_cutoff <- function(data, cutoff, colnames){
-    print(paste("Apply rpkm cutoff ", cutoff, sep=""))
-    data = data[data[,colnames[1]] >= cutoff | data[,colnames[2]] >= cutoff,]
-    return( data )
-}
 
+assert_args <- function(args) {
+  print("Check input parameters")
+  if (is.null(args$ualias) | is.null(args$talias)) {
+    print(
+      "--ualias or --talias were not set, use default values based on the expression file names"
+    )
+    for (i in 1:length(args$untreated)) {
+      args$ualias <- append(args$ualias, head(unlist(
+        strsplit(basename(args$untreated[i]), ".", fixed = TRUE)
+      ), 1))
+    }
+    for (i in 1:length(args$treated)) {
+      args$talias <- append(args$talias, head(unlist(
+        strsplit(basename(args$treated[i]), ".", fixed = TRUE)
+      ), 1))
+    }
+  } else {
+    if ((length(args$ualias) != length(args$untreated)) |
+      (length(args$talias) != length(args$treated))) {
+      cat("\nNot correct number of inputs provided as -u, -t, -ua, -ut")
+      quit(
+        save = "no",
+        status = 1,
+        runLast = FALSE
+      )
+    }
+  }
 
-assert_args <- function(args){
-    print("Check input parameters")
-    if (is.null(args$ualias) | is.null(args$talias)){
-        print("--ualias or --talias were not set, use default values based on the expression file names")
-        for (i in 1:length(args$untreated)) {
-            args$ualias = append(args$ualias, head(unlist(strsplit(basename(args$untreated[i]), ".", fixed = TRUE)), 1))
-        }
-        for (i in 1:length(args$treated)) {
-            args$talias = append(args$talias, head(unlist(strsplit(basename(args$treated[i]), ".", fixed = TRUE)), 1))
-        }
+  if (length(args$treated) == 1 || length(args$untreated) == 1) {
+    args$batchfile <- NULL # reset batchfile to NULL. We don't need it for DESeq even if it was provided
+  }
+
+  if (!is.null(args$batchfile)) {
+    batch_metadata <- read.table(
+      args$batchfile,
+      sep = get_file_type(args$batchfile),
+      row.names = 1,
+      col.names = c("name", "batch"),
+      header = FALSE,
+      stringsAsFactors = FALSE
+    )
+    rownames(batch_metadata) <- gsub("'|\"| ", "_", rownames(batch_metadata))
+    if (all(is.element(c(args$ualias, args$talias), rownames(batch_metadata)))) {
+      args$batchfile <- batch_metadata # dataframe
     } else {
-        if ( (length(args$ualias) != length(args$untreated)) | (length(args$talias) != length(args$treated)) ){
-            cat("\nNot correct number of inputs provided as -u, -t, -ua, -ut")
-            quit(save = "no", status = 1, runLast = FALSE)
-        }
+      cat("\nMissing values in batch metadata file. Skipping multi-factor analysis\n")
+      args$batchfile <- NULL
     }
+  }
 
-    if (length(args$treated) == 1 || length(args$untreated) == 1){
-        args$batchfile <- NULL  # reset batchfile to NULL. We don't need it for DESeq even if it was provided
-    }
-
-    if (!is.null(args$batchfile)){
-        batch_metadata <- read.table(
-            args$batchfile,
-            sep=get_file_type(args$batchfile),
-            row.names=1,
-            col.names=c("name", "batch"),
-            header=FALSE,
-            stringsAsFactors=FALSE
-        )
-        rownames(batch_metadata) <- gsub("'|\"| ", "_", rownames(batch_metadata))
-        if (all(is.element(c(args$ualias, args$talias), rownames(batch_metadata)))){
-            args$batchfile <- batch_metadata  # dataframe
-        } else {
-            cat("\nMissing values in batch metadata file. Skipping multi-factor analysis\n")
-            args$batchfile = NULL
-        }
-    } 
-
-    return (args)
+  return(args)
 }
 
 
@@ -477,24 +612,20 @@ get_args <- function(){
         help="Name for treated (condition 2), use only letters and numbers",
         type="character", default="treated"
     )
-    parser$add_argument(
-        "-bf", "--batchfile",
-        help="Metadata file for multi-factor analysis. Headerless TSV/CSV file. First column - names from --ualias and --talias, second column - batch group name. Default: None",
-        type="character"
-    )
-    parser$add_argument(
-        "-cu", "--cutoff",
-        help="Minimum threshold for rpkm filtering. Default: 5",
-        type="double", default=5
-    )
-    parser$add_argument(
-        "--padj",
-        help=paste(
-            "In the exploratory visualization part of the analysis output only features",
-            "with adjusted P-value not bigger than this value. Default: 0.05"
-        ),
-        type="double", default=0.05
-    )
+    parser$add_argument("-bf", "--batchfile",
+    help = "Metadata file for multi-factor analysis. Headerless TSV/CSV file. First column - names from --ualias and --talias, second column - batch group name. Default: None", type =
+      "character"
+  )
+  parser$add_argument(
+    "--fdr",
+    help = paste(
+      "In the exploratory visualization part of the analysis output only features",
+      "with adjusted p-value (FDR) not bigger than this value. Also the significance",
+      "cutoff used for optimizing the independent filtering. Default: 0.1."
+    ),
+    type = "double",
+    default = 0.1
+  )
     parser$add_argument(
         "--cluster",
         help=paste(
@@ -505,6 +636,51 @@ get_args <- function(){
         type="character",
         choices=c("row", "column", "both")
     )
+    parser$add_argument(
+    "--batchcorrection",
+    help = paste(
+      "Specifies the batch correction method to be applied.
+      - 'combatseq' applies ComBat_seq at the beginning of the analysis, removing batch effects from the design formula before differential expression analysis.
+      - 'limmaremovebatcheffect' applies removeBatchEffect from the limma package after differential expression analysis, incorporating batch effects into the model during DE analysis.
+      - Default: none"
+    ),
+    type = "character",
+    choices = c("none", "combatseq", "limmaremovebatcheffect"),
+    default = "none"
+  )
+  parser$add_argument(
+    "--regulation",
+    help = paste(
+      "Direction of differential expression comparison. β is the log2 fold change.",
+      "'both' for both up and downregulated genes (|β| > lfcThreshold for greaterAbs and |β| < lfcThreshold for lessAbs, with p-values being two-tailed or maximum of the upper and lower tests, respectively); ",
+      "'up' for upregulated genes (β > lfcThreshold in condition2 compared to condition1); ",
+      "'down' for downregulated genes (β < -lfcThreshold in condition2 compared to condition1). ",
+      "Default: both"
+    ),
+    type = "character",
+    choices = c("both", "up", "down"),
+    default = "both"
+  )
+  parser$add_argument(
+    "--lfcthreshold",
+    help = paste(
+      "Log2 fold change threshold for determining significant differential expression.",
+      "Genes with absolute log2 fold change greater than this threshold will be considered.",
+      "Default: 0.59 (about 1.5 fold change)"
+    ),
+    type = "double",
+    default = 0.59
+  )
+  parser$add_argument(
+    "--use_lfc_thresh",
+    help = paste(
+      "Flag to indicate whether to use lfcthreshold as the null hypothesis value in the results function call.",
+      "If TRUE, lfcthreshold is used in the hypothesis test (i.e., genes are tested against this threshold).",
+      "If FALSE, the null hypothesis is set to 0, and lfcthreshold is used only as a downstream filter.",
+      "Default: FALSE"
+    ),
+    action = "store_true"
+  )
     parser$add_argument(
         "--rowdist",
         help=paste(
@@ -521,16 +697,14 @@ get_args <- function(){
             "provided. Default: euclid"
         ),
         type="character", default="euclid",
-        choices=c("cosangle", "abscosangle", "euclid", "abseuclid", "cor", "abscor")
+        choices = c(
+      "cosangle",
+      "abscosangle",
+      "euclid",
+      "abseuclid",
+      "cor",
+      "abscor"
     )
-    parser$add_argument(
-        "--center",
-        help=paste(
-            "Apply mean centering for feature expression prior to running",
-            "clustering by row. Ignored when --cluster is not row or both.",
-            "Default: do not centered"
-        ),
-        action="store_true"
     )
     parser$add_argument(
         "-o", "--output",
@@ -561,93 +735,138 @@ register(MulticoreParam(args$threads))
 
 # Load isoforms/genes/tss files
 raw_data <- load_isoform_set(args$treated, args$talias, READ_COL, RPKM_COL, RPKM_TREATED_ALIAS, args$tname, INTERSECT_BY, args$digits, args$batchfile, load_isoform_set(args$untreated, args$ualias, READ_COL, RPKM_COL, RPKM_UNTREATED_ALIAS, args$uname, INTERSECT_BY, args$digits, args$batchfile))
-collected_isoforms <- apply_cutoff(raw_data$collected_isoforms, args$cutoff, raw_data$rpkm_colnames)
-read_count_cols = raw_data$read_colnames
-column_data = raw_data$column_data
+collected_isoforms <- raw_data$collected_isoforms
+read_count_cols <- raw_data$read_colnames
+column_data <- raw_data$column_data
 print(paste("Number of rows common for all input files ", nrow(collected_isoforms), sep=""))
 print(head(collected_isoforms))
 print("DESeq categories")
 print(column_data)
 print("DESeq count data")
-countData = collected_isoforms[read_count_cols]
+countData <- collected_isoforms[read_count_cols]
 print(head(countData))
 
 # Run DESeq or DESeq2
-if (length(args$treated) > 1 && length(args$untreated) > 1){
-    
-    suppressMessages(library(DESeq2))
+if (length(args$treated) > 1 && length(args$untreated) > 1) {
+  suppressMessages(library(DESeq2))
 
-    if (!is.null(args$batchfile)){
-        print("Run DESeq2 multi-factor analysis")
-        design=~batch+conditions  # We use simple +, because batch is not biologically interesting for us.
+  if (!is.null(args$batchfile)) {
+    if (args$batchcorrection == "combatseq") {
+      design <- ~conditions
+      print(paste(
+        "Batch-correction of",
+        args$batchfile,
+        "using ComBat-Seq"
+      ))
+      counts_data <- ComBat_seq(
+        as.matrix(counts_data),
+        covar_mod = model.matrix(design, data = colData),
+        batch = metadata[[args$batchfile]],
+        # columns from counts data are alread ordered by rownames from metadata
+        group = NULL
+      )
     } else {
-        print("Run DESeq2 analysis")
-        design=~conditions
+      if (args$batchcorrection == "limmaremovebatcheffect") {
+        print(paste(
+          "Including",
+          args$batchfile,
+          "as part of the design-formula"
+        ))
+        design <- ~ conditions + batch # We use simple +, because batch is not biologically interesting for us.
+      }
     }
-    
-    dse <- DESeqDataSetFromMatrix(countData=countData, colData=column_data, design=design)
-    dsq <- DESeq(dse)
-    # check size/normalization factors
-    print("DESeq sizeFactors (dsq)")
-    print(dsq$sizeFactor)
+  } else {
+    design <- ~conditions
+  }
 
-    # for norm count file. Batch correction doens't influence it
-    normCounts <- counts(dsq, normalized=TRUE)
-    rownames(normCounts) <- toupper(collected_isoforms[,c("GeneId")])
+  print("Run DESeq2 analysis")
 
-    res <- results(dsq, contrast=c("conditions", args$uname, args$tname))
-    export_ma_plot(res, paste(args$output, "_ma_plot", sep=""))
+  dse <- DESeqDataSetFromMatrix(
+    countData = countData,
+    colData = column_data,
+    design = design
+  )
+  dsq <- DESeq(dse)
 
-    # for PCA and heatmap
-    vst <- varianceStabilizingTransformation(dse)
+  # for norm count file. Batch correction doens't influence it
+  normCounts <- counts(dsq, normalized = TRUE)
+  rownames(normCounts) <- toupper(collected_isoforms[, c("GeneId")])
 
-    if (!is.null(args$batchfile)){
-        assay(vst) <- limma::removeBatchEffect(
-            assay(vst),
-            vst$batch,
-            design=stats::model.matrix(stats::as.formula("~conditions"), column_data)
-        )
-        pca_intgroup <- c("conditions", "batch")
+  # Determine altHypothesis and lfcThreshold based on the flag
+  altHypothesis <- if (args$regulation == "up") {
+    "greater"
+  } else if (args$regulation == "down") {
+    "less"
+  } else {
+    "greaterAbs"
+  }
+
+  lfcThreshold <- if (args$use_lfc_thresh) args$lfcthreshold else 0
+
+  # Perform DESeq2 results analysis
+  res <- results(
+    dsq,
+    contrast = c("conditions", args$uname, args$tname),
+    alpha = args$fdr,
+    lfcThreshold = lfcThreshold,
+    independentFiltering = TRUE,
+    altHypothesis = altHypothesis
+  )
+
+  generate_md(args$batchcorrection, args$batchfile, res, paste0(args$output, "_summary.md", collapse = ""))
+
+  export_ma_plot(res, paste(args$output, "_ma_plot", sep = ""))
+
+  # for PCA and heatmap
+
+  if (!is.null(args$batchfile)) {
+    if (args$batchcorrection == "limma") {
+      vst <- DESeq2::rlog(dse, blind = FALSE)
+      assay(vst) <- limma::removeBatchEffect(
+        assay(vst),
+        vst$batch,
+        design = stats::model.matrix(stats::as.formula("~conditions"), column_data)
+      )
+      pca_intgroup <- c("conditions", "batch")
     } else {
-        pca_intgroup <- c("conditions")
+      vst <- DESeq2::varianceStabilizingTransformation(dse, blind = FALSE)
+      pca_intgroup <- c("conditions", "batch")
     }
-    export_pca_plot(vst, paste(args$output, "_pca_plot", sep=""), pca_intgroup)
-    export_mds_html_plot(                                                          # need it only whne we have at least three samples
-        norm_counts_data=vst,
-        location=paste(args$output, "mds_plot.html", sep="_")
-    )
-    vsd <- assay(vst)
-    rownames(vsd) <- collected_isoforms[,c("GeneId")]
-    mat <- vsd[order(rowMeans(counts(dsq, normalized=TRUE)), decreasing=TRUE)[1:30],]
-    DESeqRes <- as.data.frame(res[, c(1, 2, 5, 6)])
+  } else {
+    vst <- DESeq2::varianceStabilizingTransformation(dse, blind = FALSE)
+    pca_intgroup <- c("conditions")
+  }
+
+  export_pca_plot(vst, paste(args$output, "_pca_plot", sep = ""), pca_intgroup)
+  export_mds_html_plot(
+    # need it only whne we have at least three samples
+    norm_counts_data = vst,
+    location = paste(args$output, "mds_plot.html", sep = "_")
+  )
+  vsd <- assay(vst)
+  rownames(vsd) <- collected_isoforms[, c("GeneId")]
+  mat <- vsd[order(rowMeans(counts(dsq, normalized = TRUE)),
+    decreasing =
+      TRUE
+  )[1:30], ]
+  DESeqRes <- as.data.frame(res[, c(1, 2, 5, 6)])
 } else {
-    print("Run DESeq analysis")
-    suppressMessages(library(DESeq))
-    cds <- newCountDataSet(countData, column_data[,"conditions"])
-    cdsF <- estimateSizeFactors(cds)
-    cdsD <- estimateDispersions(cdsF, method="blind", sharingMode="fit-only", fitType="local")
-    normCounts <- counts(cdsD, normalized=TRUE)
-    rownames(normCounts) <- toupper(collected_isoforms[,c("GeneId")])
-    res <- nbinomTest(cdsD, args$uname, args$tname)
-    infLFC <- is.infinite(res$log2FoldChange)
-    res$log2FoldChange[infLFC] <- log2((res$baseMeanB[infLFC]+0.1)/(res$baseMeanA[infLFC]+0.1))
-
-    export_ma_plot(res, paste(args$output, "_ma_plot", sep=""))
-
-    vsd <- exprs(varianceStabilizingTransformation(cdsD))
-    rownames(vsd) <- collected_isoforms[,c("GeneId")]
-    mat <- vsd[order(rowMeans(counts(cdsD, normalized=TRUE)), decreasing=TRUE)[1:30],]
-    DESeqRes <- res[, c(2, 6, 7, 8)]
-    colnames(DESeqRes)[3] <- "pvalue"  # in DESeq2 it's pvalue, need to use the same here
+  print("You are trying to run DESeq2 with only one replicate, which is not possible.")
 }
 
 # Expression data heatmap of the 30 most highly expressed genes
-export_heatmap(mat, column_data, paste(args$output, "_expression_heatmap", sep=""))
+export_heatmap(
+  mat,
+  column_data,
+  paste(args$output, "_expression_heatmap", sep = "")
+)
 
 # Filter DESeq/DESeq2 output
-DESeqRes$log2FoldChange[is.na(DESeqRes$log2FoldChange)] <- 0;
-DESeqRes$pvalue[is.na(DESeqRes$pvalue)] <- 1;
-DESeqRes$padj[is.na(DESeqRes$padj)] <- 1;
+DESeqRes$log2FoldChange[is.na(DESeqRes$log2FoldChange)] <- 0
+
+DESeqRes$pvalue[is.na(DESeqRes$pvalue)] <- 1
+
+DESeqRes$padj[is.na(DESeqRes$padj)] <- 1
 # DESeqRes <- format(DESeqRes, digits=args$digits)   # when applied, can't be used as numbers anymore
 
 # Add metadata columns to the DESeq results
@@ -663,20 +882,12 @@ write.table(collected_isoforms,
             sep="\t",
             row.names=FALSE,
             col.names=TRUE,
-            quote=FALSE)
-print(paste("Export DESeq report to ", collected_isoforms_filename, sep=""))
-
-# assemble and export all count table rows
-row_metadata <- collected_isoforms %>%
-                dplyr::mutate_at("GeneId", toupper) %>%
-                dplyr::distinct(GeneId, .keep_all=TRUE) %>%                      # to prevent from failing when input files are not grouped by GeneId
-                remove_rownames() %>%
-                column_to_rownames("GeneId") %>%                                 # fails if GeneId is not unique (when run with not grouped by gene data)
-                dplyr::select(log2FoldChange, pvalue, padj)  %>%                 # we are interested only in these three columns
-                arrange(desc(log2FoldChange))
-
-col_metadata <- column_data %>%
-                mutate_at(colnames(.), as.vector)                                # need to convert to vector, because in our metadata everything was a factor
+            quote=FALSE
+)
+print(paste("Export DESeq report to ", collected_isoforms_filename,
+  sep =
+    ""
+))
 
 print("Exporting all normalized read counts to GCT format")
 export_gct(
@@ -685,18 +896,20 @@ export_gct(
     col_metadata=col_metadata,                                   # includes samples as row names
     location=paste(args$output, "_counts_all.gct", sep="")
 )
+
 # get size of matrix before filtering
 read_count_matrix_all_size <- dim(normCounts)
 
 print(
-    paste(
-        "Filtering normalized read counts matrix for morpheus heatmap, to include",
-        "only differentially expressed features with padj <= ", args$padj
-    )
+  paste(
+    "Filtering normalized read counts matrix to include",
+    "only differentially expressed features with padj <= ",
+    args$fdr
+  )
 )
 
 row_metadata <- collected_isoforms %>%
-                dplyr::filter(.$padj<=args$padj) %>%
+                dplyr::filter(.$padj<=args$fdr) %>%
                 dplyr::mutate_at("GeneId", toupper) %>%
                 dplyr::distinct(GeneId, .keep_all=TRUE) %>%                      # to prevent from failing when input files are not grouped by GeneId
                 remove_rownames() %>%
@@ -716,11 +929,10 @@ print(dim(normCounts))
 if (!is.null(args$cluster)){
     if (args$cluster == "column" || args$cluster == "both") {
         print("Clustering filtered read counts by columns")
-        clustered_data = get_clustered_data(
-            expression_data=normCounts,
-            center=NULL,                                              # centering doesn't influence on the samples order
-            dist=args$columndist,
-            transpose=TRUE
+        clustered_data <- get_clustered_data(
+            expression_data = normCounts,
+            dist = args$columndist,
+            transpose = TRUE
         )
         col_metadata <- cbind(col_metadata, clustered_data$clusters)  # adding cluster labels
         col_metadata <- col_metadata[clustered_data$order, ]          # reordering samples order based on the HOPACH clustering resutls
@@ -728,18 +940,17 @@ if (!is.null(args$cluster)){
         print(col_metadata)
     }
     if (args$cluster == "row" || args$cluster == "both") {
-        print("Clustering filtered normalized read counts by rows")
-        clustered_data = get_clustered_data(
-            expression_data=normCounts,
-            center=if(args$center) "mean" else NULL,                  # about centering normalized data https://www.biostars.org/p/387863/
-            dist=args$rowdist,
-            transpose=FALSE
-        )
-        normCounts <- clustered_data$expression                  # can be different because of centering by rows mean
-        row_metadata <- cbind(row_metadata, clustered_data$clusters)  # adding cluster labels
-        row_metadata <- row_metadata[clustered_data$order, ]          # reordering features order based on the HOPACH clustering results
-        print("Reordered features")
-        print(head(row_metadata))
+      print("Clustering filtered normalized read counts by rows")
+      clustered_data <- get_clustered_data(
+        expression_data = normCounts,
+        dist = args$rowdist,
+        transpose = FALSE
+      )
+      normCounts <- clustered_data$expression                  # can be different because of centering by rows mean
+      row_metadata <- cbind(row_metadata, clustered_data$clusters)  # adding cluster labels
+      row_metadata <- row_metadata[clustered_data$order, ]          # reordering features order based on the HOPACH clustering results
+      print("Reordered features")
+      print(head(row_metadata))
     }
 }
 

--- a/tools/deseq-advanced.cwl
+++ b/tools/deseq-advanced.cwl
@@ -8,7 +8,7 @@ requirements:
 
 hints:
 - class: DockerRequirement
-  dockerPull: robertplayer/scidap-deseq:v1.0.0
+  dockerPull: biowardrobe2/scidap-deseq:v0.0.28
 
 
 inputs:
@@ -65,12 +65,6 @@ inputs:
     doc: |
       Unique aliases for treated expression files. Default: basenames of -t without extensions
 
-  rpkm_cutoff:
-    type: float?
-    inputBinding:
-      prefix: "-cu"
-    doc: |
-      Minimum threshold for rpkm filtering. Default: 5
 
   cluster_method:
     type:
@@ -121,22 +115,58 @@ inputs:
       Distance metric for HOPACH column clustering. Ignored if --cluster is not
       provided. Default: euclid
 
-  center_row:
-    type: boolean?
-    inputBinding:
-      prefix: "--center"
-    doc: |
-      Apply mean centering for feature expression prior to running
-      clustering by row. Ignored when --cluster is not row or both.
-      Default: do not centered
-
-  maximum_padj:
+  fdr:
     type: float?
     inputBinding:
-      prefix: "--padj"
+      prefix: "--fdr"
     doc: |
-      In the exploratory visualization part of the analysis output only features
-      with adjusted P-value not bigger than this value. Default: 0.05
+      In the exploratory visualization part of the analysis output only features,
+      with adjusted p-value (FDR) not bigger than this value. Also the significance,
+      cutoff used for optimizing the independent filtering. Default: 0.1.
+
+  lfcthreshold:
+    type: float?
+    inputBinding:
+      prefix: "--lfcthreshold"
+    doc: |
+      Log2 fold change threshold for determining significant differential expression.
+      Genes with absolute log2 fold change greater than this threshold will be considered.
+      Default: 0.59 (about 1.5 fold change)
+
+  regulation:
+    type:
+      - "null"
+      - type: enum
+        symbols:
+          - "both"
+          - "up"
+          - "down"
+    inputBinding:
+      prefix: "--regulation"
+    doc: |
+      Direction of differential expression comparison. β is the log2 fold change.
+      - 'both' for both up and downregulated genes (|β| > lfcThreshold for greaterAbs and |β| < lfcThreshold for lessAbs, with p-values being two-tailed or maximum of the upper and lower tests, respectively).
+      - 'up' for upregulated genes (β > lfcThreshold in condition2 compared to condition1).
+      - 'down' for downregulated genes (β < -lfcThreshold in condition2 compared to condition1).
+      Default: both
+    default: "both"
+
+  batchcorrection:
+    type:
+      - "null"
+      - type: enum
+        symbols:
+          - "none"
+          - "combatseq"
+          - "limmaremovebatcheffect"
+    inputBinding:
+      prefix: "--batchcorrection"
+    doc: |
+      Specifies the batch correction method to be applied.
+      - 'combatseq' applies ComBat_seq at the beginning of the analysis, removing batch effects from the design formula before differential expression analysis.
+      - 'limmaremovebatcheffect' applies removeBatchEffect from the limma package after differential expression analysis, incorporating batch effects into the model during DE analysis.
+      - Default: none
+    default: "none"
 
   batch_file:
     type: File?
@@ -168,6 +198,11 @@ outputs:
     type: File
     outputBinding:
       glob: "*report.tsv"
+
+  deseq_summary_md:
+    type: File
+    outputBinding:
+      glob: "*summary.md"
 
   read_counts_file_all:
     type: File
@@ -303,11 +338,14 @@ s:about: |
   usage: /Users/kot4or/workspaces/cwl_ws/workflows/tools/dockerfiles/scripts/run_deseq.R
         [-h] -u UNTREATED [UNTREATED ...] -t TREATED [TREATED ...]
         [-ua [UALIAS ...]] [-ta [TALIAS ...]] [-un UNAME] [-tn TNAME]
-        [-bf BATCHFILE] [-cu CUTOFF] [--padj PADJ]
+        [-bf BATCHFILE] [-cu CUTOFF] [--fdr FDR]
+        [--regulation {both,up,down}]
+        [--lfcthreshold LFCTHRESHOLD]
+        [--batchcorrection {none, combatseq,limmaremovebatcheffect}]
         [--cluster {row,column,both}]
         [--rowdist {cosangle,abscosangle,euclid,abseuclid,cor,abscor}]
         [--columndist {cosangle,abscosangle,euclid,abseuclid,cor,abscor}]
-        [--center] [-o OUTPUT] [-d DIGITS] [-p THREADS]
+        [-o OUTPUT] [-d DIGITS] [-p THREADS]
 
   Run BioWardrobe DESeq/DESeq2 for untreated-vs-treated groups (condition-1-vs-
   condition-2)
@@ -337,11 +375,9 @@ s:about: |
                           TSV/CSV file. First column - names from --ualias and
                           --talias, second column - batch group name. Default:
                           None
-    -cu CUTOFF, --cutoff CUTOFF
-                          Minimum threshold for rpkm filtering. Default: 5
-    --padj PADJ           In the exploratory visualization part of the analysis
-                          output only features with adjusted P-value not bigger
-                          than this value. Default: 0.05
+    --fdr FDR             In the exploratory visualization part of the analysis output only features,
+                          with adjusted p-value (FDR) not bigger than this value. Also the significance,
+                          cutoff used for optimizing the independent filtering. Default: 0.1.
     --cluster {row,column,both}
                           Hopach clustering method to be run on normalized read
                           counts for the exploratory visualization part of the
@@ -352,12 +388,22 @@ s:about: |
     --columndist {cosangle,abscosangle,euclid,abseuclid,cor,abscor}
                           Distance metric for HOPACH column clustering. Ignored
                           if --cluster is not provided. Default: euclid
-    --center              Apply mean centering for feature expression prior to
-                          running clustering by row. Ignored when --cluster is
-                          not row or both. Default: do not centered
     -o OUTPUT, --output OUTPUT
                           Output prefix. Default: deseq
     -d DIGITS, --digits DIGITS
                           Precision, number of digits to print. Default: 3
     -p THREADS, --threads THREADS
                           Threads
+    --lfcthreshold LFCTHRESHOLD
+                        Log2 fold change threshold for determining significant differential expression.
+                        Genes with absolute log2 fold change greater than this threshold will be considered.
+                        Default: 0.59 (about 1.5 fold change)
+  --regulation {both,up,down}
+                        Direction of differential expression comparison.
+                        'up' for upregulated genes, 'down' for downregulated genes,
+                        'both' for both up and downregulated genes. Default: both
+  --batchcorrection {none, combatseq,limmaremovebatcheffect}
+                        Specifies the batch correction method to be applied.
+                        - 'combatseq' applies ComBat_seq at the beginning of the analysis, removing batch effects from the design formula before differential expression analysis.
+                        - 'limmaremovebatcheffect' applies removeBatchEffect from the limma package after differential expression analysis, incorporating batch effects into the model during DE analysis.
+                        - Default: none


### PR DESCRIPTION
- Added optional --batchcorrection parameter for DESeq2 (combatseq (provided design-formula) or limma)
- Changed default adjusted p-value to 0.1 (in correspondance with alpha)
- Added regulation parameter for DESeq2 (up, down, both) and appropriate altHypothesis
- Added --lfcthreshold parameter for DESeq2 (changed default to 0.59, because it has more biological sense)
- Changed center to min-max scaling before HOPACH clustering
- Added blind = F parameter for DESeq2 vst and rlog (to take into account design-formula)
- Removed RPKM filtering (not needed for DESeq2 as explained by developer while independence filtering provided)