### PR TITLE
Update docker image for an old deseq multi factor analysis to not fail when one of the default contrasts is not correct

### DIFF
--- a/tools/deseq-multi-factor.cwl
+++ b/tools/deseq-multi-factor.cwl
@@ -8,7 +8,7 @@ requirements:
 
 hints:
 - class: DockerRequirement
-  dockerPull: biowardrobe2/deseq:v0.0.6
+  dockerPull: biowardrobe2/deseq:v0.0.7
 
 
 inputs:


### PR DESCRIPTION
To make it not fails when there is not enough samples for some of the autoestimated contrasts