### PR TITLE
fix upstream input refs for second upstream selected

### DIFF
--- a/workflows/deseq-for-spikein.cwl
+++ b/workflows/deseq-for-spikein.cwl
@@ -63,7 +63,7 @@ inputs:
     format: "http://edamontology.org/format_3752"
     label: "RNA-Seq experiments (condition 2, e.g. 'control')"
     doc: "CSV/TSV input files grouped by isoforms (condition 2, e.g. 'control')"
-    'sd:upstreamSource': "rnaseq_cond_2/rpkm_isoforms"
+    'sd:upstreamSource': "rnaseq_cond_2/rpkm_isoforms_ercc_normalized"
     'sd:localLabel': true
 
   rpkm_genes_cond_2:
@@ -74,7 +74,7 @@ inputs:
     format: "http://edamontology.org/format_3752"
     label: "RNA-Seq experiments (condition 2, e.g. 'control')"
     doc: "CSV/TSV input files grouped by genes (condition 2, e.g. 'control')"
-    'sd:upstreamSource': "rnaseq_cond_2/rpkm_genes"
+    'sd:upstreamSource': "rnaseq_cond_2/rpkm_genes_ercc_normalized"
 
   rpkm_common_tss_cond_2:
     type:
@@ -84,7 +84,7 @@ inputs:
     format: "http://edamontology.org/format_3752"
     label: "RNA-Seq experiments (condition 2, e.g. 'control')"
     doc: "CSV/TSV input files grouped by common TSS (condition 2, e.g. 'control')"
-    'sd:upstreamSource': "rnaseq_cond_2/rpkm_common_tss"
+    'sd:upstreamSource': "rnaseq_cond_2/rpkm_common_tss_ercc_normalized"
 
   group_by:
     type:

--- a/workflows/genelists-deseq-only.cwl
+++ b/workflows/genelists-deseq-only.cwl
@@ -29,7 +29,6 @@ requirements:
     - "trim-rnaseq-pe-smarter-dutp.cwl"
     - "trim-rnaseq-se-dutp.cwl"
     - "trim-quantseq-mrnaseq-se-strand-specific.cwl"
-    - "trim-rnaseq-pe-ercc.cwl"
 
 
 inputs:

--- a/workflows/genelists-deseq-only.cwl
+++ b/workflows/genelists-deseq-only.cwl
@@ -29,6 +29,7 @@ requirements:
     - "trim-rnaseq-pe-smarter-dutp.cwl"
     - "trim-rnaseq-se-dutp.cwl"
     - "trim-quantseq-mrnaseq-se-strand-specific.cwl"
+    - "trim-rnaseq-pe-ercc.cwl"
 
 
 inputs:


### PR DESCRIPTION
updates deseq-spikein so that the second upstream group uses the same (normalized) input refs as the first upstream group.